### PR TITLE
[ back / feat ] : 119 고객 센터 채팅 기능 구현 완료

### DIFF
--- a/backend/src/main/java/com/example/backend/chat/chatMessage/dto/request/ChatMessageRequestDto.java
+++ b/backend/src/main/java/com/example/backend/chat/chatMessage/dto/request/ChatMessageRequestDto.java
@@ -21,4 +21,5 @@ public class ChatMessageRequestDto {
     private Long userId;
     private Long roomId;
     private String message;// 메세지
+
 }

--- a/backend/src/main/java/com/example/backend/chat/chatMessage/dto/response/ChatResponseDto.java
+++ b/backend/src/main/java/com/example/backend/chat/chatMessage/dto/response/ChatResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.backend.chat.chatMessage.dto.response;
 
 import com.example.backend.chat.chatMessage.entity.ChatMessage;
+import com.example.backend.enums.ChatMessageStatus;
 import com.example.backend.enums.ChatStatus;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -15,13 +16,13 @@ public class ChatResponseDto {
     private String sender;       // 보낸 사람 닉네임
     private String message;      // 메시지 내용
     private LocalDateTime createDate; // 메시지 생성 시간
-    private ChatStatus chatStatus;
+    private ChatMessageStatus chatStatus; //메시지 타입
 
     public ChatResponseDto(ChatMessage chatMessage) {
         this.roomId = chatMessage.getChatRoom().getId();
         this.sender = chatMessage.getUser().getName();
         this.message = chatMessage.getMessage();
         this.createDate = chatMessage.getCreatedAt();
-        this.chatStatus = getChatStatus();
+        this.chatStatus = chatMessage.getMessageStatus();
     }
 }

--- a/backend/src/main/java/com/example/backend/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/chat/chatMessage/service/ChatMessageService.java
@@ -120,8 +120,6 @@ public class ChatMessageService {
                         .messageStatus(ChatMessageStatus.LEAVE)
                         .build();
                 chatUser.setChatStatus(ChatStatus.LEAVE);
-
-
                 chatUserRepository.save(chatUser);
             }
             default -> throw new BusinessLogicException(ExceptionCode.INVALID_CHAT_ROOM_TYPE);

--- a/backend/src/main/java/com/example/backend/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/chat/chatMessage/service/ChatMessageService.java
@@ -120,10 +120,9 @@ public class ChatMessageService {
                         .messageStatus(ChatMessageStatus.LEAVE)
                         .build();
                 chatUser.setChatStatus(ChatStatus.LEAVE);
+
+
                 chatUserRepository.save(chatUser);
-                chatRoomService.leaveChatRoom(chatRoom.getId());
-
-
             }
             default -> throw new BusinessLogicException(ExceptionCode.INVALID_CHAT_ROOM_TYPE);
         }
@@ -134,7 +133,6 @@ public class ChatMessageService {
     public Page<ChatMessage> getChatMessage(Long roomId, Pageable pageable){
         User user = userService.findById(tokenService.getIdFromToken());
         ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
-
 
         //참여중인 채팅방 아니면 메시지 조회 못함
         if(chatUserRepository.findByUserAndChatRoom(user,chatRoom).isEmpty()){

--- a/backend/src/main/java/com/example/backend/chat/chatUser/entity/ChatUser.java
+++ b/backend/src/main/java/com/example/backend/chat/chatUser/entity/ChatUser.java
@@ -48,7 +48,6 @@ public class ChatUser extends Auditable {
     @Column(name = "is_creator", nullable = false)
     private boolean isCreator; //true일 경우 최초 생성자
 
-
     @ManyToOne
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;

--- a/backend/src/main/java/com/example/backend/chat/chatUser/repository/ChatUserRepository.java
+++ b/backend/src/main/java/com/example/backend/chat/chatUser/repository/ChatUserRepository.java
@@ -18,6 +18,7 @@ public interface ChatUserRepository extends JpaRepository<ChatUser, Long> {
 
     Optional<ChatUser> findByUserAndChatRoom(User user, ChatRoom chatRoom);
     List<ChatUser> findByChatRoom(ChatRoom chatRoom);
+    void deleteById(Long id);
 
 
     // ChatStatus : ENTER, LEAVE, CREATE

--- a/backend/src/main/java/com/example/backend/chat/chatUser/repository/ChatUserRepository.java
+++ b/backend/src/main/java/com/example/backend/chat/chatUser/repository/ChatUserRepository.java
@@ -20,6 +20,8 @@ public interface ChatUserRepository extends JpaRepository<ChatUser, Long> {
     List<ChatUser> findByChatRoom(ChatRoom chatRoom);
     void deleteById(Long id);
 
+    List<ChatUser> findByUser(User user);
+
 
     // ChatStatus : ENTER, LEAVE, CREATE
     Page<ChatUser> findByUserAndChatRoomRoomTypeAndChatStatusIn(

--- a/backend/src/main/java/com/example/backend/chat/chatroom/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/controller/ChatRoomController.java
@@ -101,6 +101,18 @@ public class ChatRoomController {
         );
     }
 
+    @GetMapping("/{roomId}/opponent")
+    @Operation(
+            summary = "채팅 상대방 이름 조회",
+            description = "채팅방 ID를 기반으로 현재 로그인한 유저를 제외한 상대방의 이름을 반환합니다."
+    )
+    public ResponseEntity<ApiResponse<String>> getOpponentName(@PathVariable Long roomId) {
+        String opponentName = chatRoomService.findOpponentName(roomId);
+        return ResponseEntity.ok(ApiResponse.of(200, "상대방 이름 조회 완료", opponentName));
+    }
+
+
+
     @GetMapping ("/exists")
     @Operation(
             summary = "1:1 채팅방 존재 여부 확인",

--- a/backend/src/main/java/com/example/backend/chat/chatroom/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/controller/ChatRoomController.java
@@ -113,7 +113,7 @@ public class ChatRoomController {
 
 
 
-    @GetMapping ("/exists")
+    @GetMapping ("/exists/users")
     @Operation(
             summary = "1:1 채팅방 존재 여부 확인",
             description = "두 사용자 간 1:1 채팅방이 이미 존재하는지 확인합니다."
@@ -167,6 +167,26 @@ public class ChatRoomController {
                 )
         );
     }
+
+    @GetMapping("/exist/support")
+    @Operation(
+            summary = "고객센터 채팅방 존재 여부 확인",
+            description = "현재 로그인한 사용자가 고객센터(SUPPORT) 채팅방을 보유하고 있는지 확인합니다. " +
+                    "존재하면 true, 없으면 false를 반환합니다."
+    )
+    public ResponseEntity<ApiResponse<Boolean>> checkSupportChatRoomExistence() {
+        boolean exists = chatRoomService.existsSupportChatRoomForCurrentUser();
+
+        return ResponseEntity.ok(
+                ApiResponse.of(
+                        HttpStatus.OK.value(),
+                        "고객센터 채팅방 존재 여부 조회 성공",
+                        exists
+                )
+        );
+    }
+
+
 
 
 

--- a/backend/src/main/java/com/example/backend/chat/chatroom/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/controller/ChatRoomController.java
@@ -157,6 +157,8 @@ public class ChatRoomController {
     )
     public ResponseEntity<ApiResponse<Void>> leaveChatRoom(@PathVariable Long roomId) {
         chatRoomService.leaveChatRoom(roomId);
+
+
         return ResponseEntity.ok(
                 ApiResponse.of(
                         HttpStatus.OK.value(),

--- a/backend/src/main/java/com/example/backend/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/entity/ChatRoom.java
@@ -47,7 +47,7 @@ public class ChatRoom extends Auditable { // Auditable 상속
     private ChatRoomType roomType;
 
 
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE, orphanRemoval = true,  fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "chatRoom", fetch = FetchType.EAGER)
     List<ChatUser> chatUserList = new ArrayList<>();
 
 

--- a/backend/src/main/java/com/example/backend/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/entity/ChatRoom.java
@@ -52,6 +52,8 @@ public class ChatRoom extends Auditable { // Auditable 상속
 
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE, orphanRemoval = true,  fetch = FetchType.EAGER)
-    List<ChatMessage> chatMessageListi = new ArrayList<>();
+    List<ChatMessage> chatMessageList = new ArrayList<>();
+
+
 
 }

--- a/backend/src/main/java/com/example/backend/chat/chatroom/service/ChatRoomService.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/service/ChatRoomService.java
@@ -145,7 +145,7 @@ public class ChatRoomService {
         return chatUsers.map(ChatUser::getChatRoom);
     }
 
-    public void leaveChatRoom( Long roomId) {
+    public void leaveChatRoom(Long roomId) {
         User user = userService.findById(tokenService.getIdFromToken());
         ChatRoom chatRoom = findId(roomId);
         ChatUser chatUser = chatUserRepository.findByUserAndChatRoom(user,chatRoom)
@@ -242,26 +242,28 @@ public class ChatRoomService {
 
 
 
-    //현재 채팅하고 있는 상대방 조회 ( 1:1, 고객 채팅에서만 사용 )
-    public String findOpponentName(Long roomId){
+    // 현재 채팅하고 있는 상대방 조회 (1:1, 고객센터 채팅에서만 사용)
+    public String findOpponentName(Long roomId) {
 
-        //1:1, 고객센터 채팅에만 사용
         User loginUser = userService.findById(tokenService.getIdFromToken());
         ChatRoom room = findId(roomId);
 
         List<ChatUser> chatUserList = chatUserRepository.findByChatRoom(room);
 
-        if(chatUserList.isEmpty()) {
+        if (chatUserList.isEmpty()) {
             return null;
         }
 
         return chatUserList.stream()
-                .map(ChatUser::getUser)
-                .filter(user -> !user.getId().equals(loginUser.getId())) // 현재 유저 제외
-                .map(User::getName) // 상대방의 이름 (닉네임 등)
+                .filter(chatUser ->
+                        !chatUser.getUser().getId().equals(loginUser.getId()) && // 현재 사용자 제외
+                                chatUser.getChatStatus() != ChatStatus.LEAVE             // 나간 사용자 제외
+                )
+                .map(chatUser -> chatUser.getUser().getName()) // 상대방 이름 반환
                 .findFirst()
                 .orElse(null); // 상대방이 없을 경우 null
     }
+
 
 
     public ChatRoom findId(Long roomId){

--- a/backend/src/main/java/com/example/backend/chat/chatroom/service/ChatRoomService.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/service/ChatRoomService.java
@@ -241,6 +241,29 @@ public class ChatRoomService {
     }
 
 
+
+    //현재 채팅하고 있는 상대방 조회 ( 1:1, 고객 채팅에서만 사용 )
+    public String findOpponentName(Long roomId){
+
+        //1:1, 고객센터 채팅에만 사용
+        User loginUser = userService.findById(tokenService.getIdFromToken());
+        ChatRoom room = findId(roomId);
+
+        List<ChatUser> chatUserList = chatUserRepository.findByChatRoom(room);
+
+        if(chatUserList.isEmpty()) {
+            return null;
+        }
+
+        return chatUserList.stream()
+                .map(ChatUser::getUser)
+                .filter(user -> !user.getId().equals(loginUser.getId())) // 현재 유저 제외
+                .map(User::getName) // 상대방의 이름 (닉네임 등)
+                .findFirst()
+                .orElse(null); // 상대방이 없을 경우 null
+    }
+
+
     public ChatRoom findId(Long roomId){
         return chatRoomRepository.findById(roomId)
                 .orElseThrow(()->new BusinessLogicException(ExceptionCode.CHAT_ROOM_FOUND));

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -93,7 +93,7 @@ public class UserService {
 
         User manager =User.builder()
                 .email(initialManagerSignupRequestDto.getEmail())
-                .name(initialManagerSignupRequestDto.getName())
+                .name(initialManagerSignupRequestDto.getName()+" 매니저")
                 .password(passwordEncoder.encode(initialManagerSignupRequestDto.getPassword()))
                 .phoneNumber(initialManagerSignupRequestDto.getPhoneNumber())
                 .initialManager(true)
@@ -114,7 +114,7 @@ public class UserService {
 
         User manager =User.builder()
                 .email(managerSignupRequestDto.getEmail())
-                .name(managerSignupRequestDto.getName())
+                .name(managerSignupRequestDto.getName() +" 매니저")
                 .password(passwordEncoder.encode(managerSignupRequestDto.getPassword()))
                 .phoneNumber(managerSignupRequestDto.getPhoneNumber())
                 .managementDashboard(managementDashboard)

--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { LoginUserContext, useLoginUser } from "@/stores/auth/loginMember";
 import { Header } from "./components/Header";
 import { useNotificationStore } from "@/stores/notifications";
+import { NotificationBell } from "@/components/Notification/NotificationBell";
 
 export function ClientLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -53,7 +54,7 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
           username: userData.name,
           managementDashboardName: userData.managementDashboardName ?? "",
           departmentName: userData.departmentName ?? "",
-          role: userData.role,
+          role: userData.role ?? "user", // Provide a default role if not present
         });
 
         // SSE 연결
@@ -143,6 +144,9 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
         } bg-white`}
       >
         {!isAuthPage && <Header />}
+        <div className="fixed top-4 right-4 z-50">
+          <NotificationBell />
+        </div>
         <main
           className={`flex-1 ${!isAuthPage ? "pt-[60px]" : ""} bg-[#F4F4F4]`}
         >

--- a/frontend/src/app/chat/support/page.tsx
+++ b/frontend/src/app/chat/support/page.tsx
@@ -28,9 +28,43 @@ const SupportChatPage = () => {
     };
   }, []);
 
+  // 고객센터 채팅방 존재 여부 확인
+  const checkSupportChatRoomExistence = async (): Promise<boolean> => {
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/chats/chatRooms/exist/support`,
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          "고객센터 채팅방 존재 여부 확인 중 오류가 발생했습니다."
+        );
+      }
+
+      const data = await response.json();
+      return data.data; // true 또는 false 반환
+    } catch (error) {
+      console.error("고객센터 채팅방 존재 여부 확인 실패:", error);
+      return false; // 오류 발생 시 기본값으로 false 반환
+    }
+  };
+
   // 고객센터 채팅방 생성
   const createSupportChatRoom = async () => {
     try {
+      const exists = await checkSupportChatRoomExistence(); // 채팅방 존재 여부 확인
+      if (exists) {
+        alert("이미 고객센터 채팅방이 존재합니다.");
+        return;
+      }
+
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/chats/chatRooms`,
         {

--- a/frontend/src/app/chat/user/page.tsx
+++ b/frontend/src/app/chat/user/page.tsx
@@ -45,6 +45,7 @@ const ChatPage = () => {
             onSelectRoom={(roomId) => setSelectedRoomId(roomId)} // 선택된 채팅방 ID 설정
             client={client} // WebSocket 클라이언트 전달
             loginUserId={loginUser.id} // 로그인 유저 ID 전달
+            roomType="ONE_TO_ONE" // SUPPORT 타입 채팅방 조회
           />
         </div>
         <div>

--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -160,7 +160,11 @@ const Chat: React.FC<Props> = ({ roomId, client, loginUserId }) => {
               <strong>{msg.sender}</strong>: {msg.message} <br />
               {msg.chatStatus !== "ENTER" && (
                 <small className="text-gray-500 ml-2">
-                  {new Date(msg.createDate).toLocaleString()}
+                  {new Date(msg.createDate).toLocaleDateString()}{" "}
+                  {new Date(msg.createDate).toLocaleTimeString([], {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
                 </small>
               )}
             </div>

--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -54,6 +54,7 @@ const Chat: React.FC<Props> = ({ roomId, client, loginUserId }) => {
         }
 
         const data = await response.json();
+        console.log("로드된 메시지:", data.data.content);
         setMessages(data.data.content.reverse()); // 최신 메시지가 아래로 가도록 정렬
       } catch (error) {
         console.error("채팅 메시지 로드 실패:", error);
@@ -152,12 +153,19 @@ const Chat: React.FC<Props> = ({ roomId, client, loginUserId }) => {
       )}
 
       <div className="h-64 overflow-y-auto border p-4 mb-4">
-        {messages.map((msg, index) => (
-          <div key={index} className="p-2 border-b">
-            <strong>{msg.sender}</strong>: {msg.message} <br />
-            <small>{new Date(msg.createDate).toLocaleString()}</small>
-          </div>
-        ))}
+        {messages.map((msg, index) => {
+          console.log("메시지 상태:", msg.chatStatus); // 디버깅용 로그
+          return (
+            <div key={index} className="p-2 border-b">
+              <strong>{msg.sender}</strong>: {msg.message} <br />
+              {msg.chatStatus !== "ENTER" && (
+                <small className="text-gray-500 ml-2">
+                  {new Date(msg.createDate).toLocaleString()}
+                </small>
+              )}
+            </div>
+          );
+        })}
       </div>
       <div className="flex">
         <input

--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -75,6 +75,7 @@ const Chat: React.FC<Props> = ({ roomId, client, loginUserId }) => {
       (message: Message) => {
         const response = JSON.parse(message.body); // 서버에서 발행된 메시지 파싱
         const receivedMessage: ChatResponseDto = response.data; // ApiResponse의 data 필드 추출
+
         setMessages((prevMessages) => [...prevMessages, receivedMessage]); // 메시지 추가
       }
     );

--- a/frontend/src/components/chat/ChatRoomList.tsx
+++ b/frontend/src/components/chat/ChatRoomList.tsx
@@ -12,12 +12,14 @@ interface Props {
   onSelectRoom: (roomId: number) => void; // 선택된 채팅방 ID를 부모 컴포넌트로 전달
   client: Client | null; // WebSocket 클라이언트
   loginUserId: number; // 현재 로그인한 유저 ID
+  roomType: string; // 채팅방 타입 (ONE_TO_ONE, SUPPORT 등)
 }
 
 const ChatRoomList: React.FC<Props> = ({
   onSelectRoom,
   client,
   loginUserId,
+  roomType,
 }) => {
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -30,7 +32,7 @@ const ChatRoomList: React.FC<Props> = ({
     const fetchChatRooms = async () => {
       try {
         const response = await fetch(
-          `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/chats/chatRooms?chatRoomType=ONE_TO_ONE&page=1&size=10`,
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/chats/chatRooms?chatRoomType=${roomType}&page=1&size=10`,
           {
             method: "GET",
             headers: {
@@ -54,7 +56,7 @@ const ChatRoomList: React.FC<Props> = ({
     };
 
     fetchChatRooms();
-  }, []);
+  }, [roomType]); // roomType이 변경될 때마다 호출
 
   // 특정 채팅방의 상대방 이름 가져오기
   const fetchOpponentName = async (roomId: number) => {

--- a/frontend/src/components/chat/UserList.tsx
+++ b/frontend/src/components/chat/UserList.tsx
@@ -56,7 +56,7 @@ const UserList: React.FC<Props> = ({
   const checkChatRoomExistence = async (userId: number): Promise<boolean> => {
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/chats/chatRooms/exists?userId=${userId}&chatRoomType=ONE_TO_ONE`,
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/chats/chatRooms/exists/users?userId=${userId}&chatRoomType=ONE_TO_ONE`,
         {
           method: "GET",
           headers: {


### PR DESCRIPTION
## 📒 개요
고객 센터 채팅 기능 외 채팅 기능 구현 

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#124 
> closed #Issue_number

<br>

## 🛠️ 작업사항

🔹 채팅방 관련 공통 기능 개선

- 채팅방 입장 메시지에는 시간 표시 생략
- 채팅 리스트에서는 날짜, 시간, 분까지만 표시
- 채팅방 이름을 상대방의 이름으로 지정 (상대방이 채팅을 입력하지 않았더라도 표시됨)
- 상대방이 채팅방을 나간 경우 “종료된 채팅”으로 표시

🔹 사용자 채팅 관련 기능
- 채팅방 생성 시, 기존 채팅 상태가 INVITED였다면 상대 유저가 방을 생성할 경우 CREATED 상태로 변경
- 채팅방 생성 시, 상대방이 채팅을 입력하지 않더라도 방 이름과 상대방이 보이도록 처리

🔹 고객센터 채팅 기능

- 고객센터 채팅 생성, 조회, 나가기 기능 구현
- 고객센터 채팅이 이미 존재하면, 새로운 고객센터 채팅방 생성 불가
- 단, 기존 고객센터 채팅방이 종료된 상태인 경우에는 생성 가능
- 프론트에서도 고객센터 채팅이 이미 존재하면 버튼이 비활성화되도록 처리

🔹 관리자(매니저) 기능
매니저 회원가입 시 자동으로 이름 뒤에 ‘매니저’ 문구 추가

<br>

## 📸 스크린샷(선택)
