### PR TITLE
[ back / feat ] 126 :  단체 채팅 기능 구현 완료, 유저가 채팅방 나갈 시 Redis에 삭제 예약 키 저장 (1분 TTL)

### DIFF
--- a/backend/src/main/java/com/example/backend/BackendApplication.java
+++ b/backend/src/main/java/com/example/backend/BackendApplication.java
@@ -3,10 +3,12 @@ package com.example.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/example/backend/chat/chatMessage/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/example/backend/chat/chatMessage/controller/ChatMessageController.java
@@ -49,7 +49,7 @@ public class ChatMessageController {
                 "메시지 확인",
                 responseMessage
         );
-
+        log.info("브로드캐스트 메시지: " + response);
         template.convertAndSend("/sub/chat/" + roomId, response);
     }
 

--- a/backend/src/main/java/com/example/backend/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/chat/chatMessage/service/ChatMessageService.java
@@ -119,12 +119,13 @@ public class ChatMessageService {
                         .user(user)
                         .messageStatus(ChatMessageStatus.LEAVE)
                         .build();
+                log.info("message확인 1 + " + chatMessage.getMessage());
                 chatUser.setChatStatus(ChatStatus.LEAVE);
                 chatUserRepository.save(chatUser);
             }
             default -> throw new BusinessLogicException(ExceptionCode.INVALID_CHAT_ROOM_TYPE);
         }
-
+        log.info("message확인 2 + " + chatMessage.getMessage());
         return chatMessageRepository.save(chatMessage);
     }
 

--- a/backend/src/main/java/com/example/backend/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/chat/chatMessage/service/ChatMessageService.java
@@ -120,8 +120,7 @@ public class ChatMessageService {
                         .messageStatus(ChatMessageStatus.LEAVE)
                         .build();
                 log.info("message확인 1 + " + chatMessage.getMessage());
-                chatUser.setChatStatus(ChatStatus.LEAVE);
-                chatUserRepository.save(chatUser);
+
             }
             default -> throw new BusinessLogicException(ExceptionCode.INVALID_CHAT_ROOM_TYPE);
         }

--- a/backend/src/main/java/com/example/backend/chat/chatroom/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/controller/ChatRoomController.java
@@ -50,6 +50,7 @@ public class ChatRoomController {
             description = "채팅방을 생성할 수 있습니다.  "
     )
     public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom(@Valid @RequestBody ChatRoomRequestDto chatRoomRequestDto) {
+        log.info("roomName !! "+chatRoomRequestDto.getRoomName());
         ChatRoomResponseDto chatRoomResponseDto = new ChatRoomResponseDto(chatRoomService.createChatRoom(chatRoomRequestDto));
 
         //ChatRoomType에 따라 다름

--- a/backend/src/main/java/com/example/backend/chat/chatroom/dto/response/ChatRoomResponseDto.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/dto/response/ChatRoomResponseDto.java
@@ -24,4 +24,6 @@ public class ChatRoomResponseDto {
         this.roomName= chatRoom.getRoomName();
         this.roomType=chatRoom.getRoomType();
     }
+
+
 }

--- a/backend/src/main/java/com/example/backend/chat/chatroom/service/ChatRoomService.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/service/ChatRoomService.java
@@ -21,6 +21,7 @@ import com.example.backend.utils.CreateRandomNumber;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -92,7 +93,7 @@ public class ChatRoomService {
 
     private ChatRoom createGroupRoom(User creator, ChatRoomRequestDto dto) {
         List<User> members = userService.findAllByIds(dto.getUserIds());
-        List<User> allUsers = List.copyOf(members);
+        List<User> allUsers = new ArrayList<>(members);
 
         // 방장은 생성자 기준으로 첫 번째에 추가
         allUsers.add(0, creator);

--- a/backend/src/main/java/com/example/backend/chat/chatroom/service/ChatRoomService.java
+++ b/backend/src/main/java/com/example/backend/chat/chatroom/service/ChatRoomService.java
@@ -103,8 +103,6 @@ public class ChatRoomService {
             throw new BusinessLogicException(ExceptionCode.MANAGER_NOT_FOUND, "문의 가능한 매니저가 없습니다.");
         }
 
-
-
         // CreateRandomNumber의 randomFromList 메서드를 사용하여 랜덤 매니저 선택
         User supportAgent = CreateRandomNumber.randomFromList(managerList);
 
@@ -112,8 +110,6 @@ public class ChatRoomService {
         if (existingRoom.isPresent()) {
             return existingRoom.get();  // 이미 존재하는 채팅방 반환
         }
-
-
 
         return createRoomBase(List.of(client, supportAgent), supportAgent.getName() + "_support_"+CreateRandomNumber.timeBasedRandomName(), ChatRoomType.SUPPORT);
     }

--- a/backend/src/main/java/com/example/backend/chat/handler/ChatRoomDeletionScheduler.java
+++ b/backend/src/main/java/com/example/backend/chat/handler/ChatRoomDeletionScheduler.java
@@ -19,7 +19,7 @@ public class ChatRoomDeletionScheduler {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatUserRepository chatUserRepository;
 
-    @Scheduled(fixedRate = 60000) // 1분마다
+    @Scheduled(fixedRate = 600000) // 1분마다
     public void deleteExpiredChatRooms() {
         Set<String> roomIds = redisService.getDeletionRoomIds();
 

--- a/backend/src/main/java/com/example/backend/chat/handler/ChatRoomDeletionScheduler.java
+++ b/backend/src/main/java/com/example/backend/chat/handler/ChatRoomDeletionScheduler.java
@@ -1,0 +1,63 @@
+package com.example.backend.chat.handler;
+
+import com.example.backend.chat.chatUser.repository.ChatUserRepository;
+import com.example.backend.chat.chatroom.entity.ChatRoom;
+import com.example.backend.chat.chatroom.repository.ChatRoomRepository;
+import com.example.backend.redis.RedisService;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ChatRoomDeletionScheduler {
+
+    private final RedisService redisService;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatUserRepository chatUserRepository;
+
+    @Scheduled(fixedRate = 60000) // 1분마다
+    public void deleteExpiredChatRooms() {
+        Set<String> roomIds = redisService.getDeletionRoomIds();
+
+        log.info("삭제 예약 대상 채팅방 ID 목록: {}", roomIds);
+
+        for (String idStr : roomIds) {
+            Long roomId = Long.valueOf(idStr);
+            String key = "chatroom:deletion:" + roomId;
+            Long ttl = redisService.getExpireSeconds(key);
+
+            log.info("채팅방 ID {}, 만료키 TTL: {}", roomId, ttl);
+
+            if (ttl == null || ttl <= 0) {
+                ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElse(null);
+
+                if (chatRoom != null) {
+                    boolean isEmptyUsers = chatUserRepository.findByChatRoom(chatRoom).isEmpty();
+                    log.info("채팅방 ID {} 채팅 유저 존재 여부: {}", roomId, !isEmptyUsers);
+
+                    if (isEmptyUsers) {
+                        try {
+                            chatRoomRepository.delete(chatRoom);
+                            log.info("🗑️ 채팅방 {} 삭제 완료", roomId);
+                        } catch (Exception e) {
+                            log.error("채팅방 {} 삭제 실패", roomId, e);
+                        }
+                    } else {
+                        log.info("채팅방 {}에 사용자가 있어 삭제하지 않음", roomId);
+                    }
+                } else {
+                    log.info("채팅방 ID {}를 DB에서 찾을 수 없음", roomId);
+                }
+
+                redisService.removeRoomIdFromDeletionList(roomId);
+                log.info("채팅방 ID {} 삭제 예약 목록에서 제거", roomId);
+            }
+        }
+
+    }
+
+}

--- a/backend/src/main/java/com/example/backend/redis/RedisService.java
+++ b/backend/src/main/java/com/example/backend/redis/RedisService.java
@@ -1,6 +1,8 @@
 package com.example.backend.redis;
 
 import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,32 @@ public class RedisService {
     public void deleteData(String key) {
         redisTemplate.delete(key);
     }
+
+    // 삭제 예약 리스트에 추가
+    public void addRoomIdToDeletionList(Long roomId) {
+        redisTemplate.opsForSet().add("chatroom:deletion:list", String.valueOf(roomId));
+    }
+
+    // 삭제 예약 리스트 가져오기
+    public Set<String> getDeletionRoomIds() {
+        return redisTemplate.opsForSet().members("chatroom:deletion:list");
+    }
+
+    // 삭제 예약 리스트에서 제거
+    public void removeRoomIdFromDeletionList(Long roomId) {
+        redisTemplate.opsForSet().remove("chatroom:deletion:list", String.valueOf(roomId));
+    }
+
+    // TTL 조회 (초 단위)
+    public Long getExpireSeconds(String key) {
+        return redisTemplate.getExpire(key, TimeUnit.SECONDS);
+    }
+
+    // 특정 패턴의 키 모두 조회
+    public Set<String> getKeys(String pattern) {
+        return redisTemplate.keys(pattern);
+    }
+
 
     //redis에 키가 존재하는지 확인
     public boolean checkExistsKey(String key) {

--- a/frontend/src/app/chat/group/page.tsx
+++ b/frontend/src/app/chat/group/page.tsx
@@ -141,14 +141,17 @@ const ChatPage = () => {
           <h2 className="text-xl font-bold mb-4">유저 리스트</h2>
           <ul className="space-y-2">
             {users.map((user) => (
-              <li key={user.id} className="flex items-center">
-                <input
-                  type="checkbox"
-                  checked={selectedUserIds.includes(user.id)}
-                  onChange={() => toggleUserSelection(user.id)}
-                  className="mr-2"
-                />
-                <span>{user.name}</span>
+              <li key={user.id} className="flex flex-col border p-2 rounded">
+                <div className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={selectedUserIds.includes(user.id)}
+                    onChange={() => toggleUserSelection(user.id)}
+                    className="mr-2"
+                  />
+                  <span className="font-medium">{user.name}</span>
+                </div>
+                <span className="text-sm text-gray-500">{user.department}</span>
               </li>
             ))}
           </ul>

--- a/frontend/src/app/chat/group/page.tsx
+++ b/frontend/src/app/chat/group/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import ChatRoomList from "@/components/chat/ChatRoomList";
+import Chat from "@/components/chat/Chat";
+import { useGlobalLoginUser } from "@/stores/auth/loginMember";
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+
+interface User {
+  id: number;
+  name: string;
+  department: string;
+}
+
+const ChatPage = () => {
+  const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
+  const [client, setClient] = useState<Client | null>(null); // WebSocket 클라이언트 상태
+  const { loginUser } = useGlobalLoginUser(); // 현재 로그인한 유저 정보
+  const managementDashboardName = loginUser.managementDashboardName; // 관리 페이지 이름
+
+  const [users, setUsers] = useState<User[]>([]); // 유저 리스트
+  const [selectedUserIds, setSelectedUserIds] = useState<number[]>([]); // 선택된 유저 ID 리스트
+  const [chatName, setChatName] = useState<string>(""); // 채팅방 이름
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // WebSocket 클라이언트 초기화
+  useEffect(() => {
+    const stompClient = new Client({
+      webSocketFactory: () =>
+        new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL}/ws-stomp`),
+      debug: (str) => console.log(str),
+    });
+
+    stompClient.activate();
+    setClient(stompClient);
+
+    return () => {
+      stompClient.deactivate();
+    };
+  }, []);
+
+  // 유저 리스트 가져오기
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/users/chat/list?managementDashboardName=${managementDashboardName}&page=1&size=10`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include",
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("유저 리스트를 가져오는 중 오류가 발생했습니다.");
+        }
+
+        const data = await response.json();
+        setUsers(data.data.content); // 유저 리스트 데이터
+        setLoading(false);
+      } catch (err) {
+        setError("유저 리스트를 가져오는 중 오류가 발생했습니다.");
+        setLoading(false);
+      }
+    };
+
+    fetchUsers();
+  }, [managementDashboardName]);
+
+  // 유저 선택 토글
+  const toggleUserSelection = (userId: number) => {
+    setSelectedUserIds(
+      (prev) =>
+        prev.includes(userId)
+          ? prev.filter((id) => id !== userId) // 이미 선택된 경우 제거
+          : [...prev, userId] // 선택되지 않은 경우 추가
+    );
+  };
+
+  // 채팅방 생성
+  const createChatRoom = async () => {
+    if (!chatName.trim()) {
+      alert("채팅방 이름을 입력하세요.");
+      return;
+    }
+
+    if (selectedUserIds.length === 0) {
+      alert("유저를 선택하세요.");
+      return;
+    }
+
+    console.log("채팅방 이름:", chatName); // 디버깅용 로그
+    console.log("선택된 유저 ID 리스트:", selectedUserIds); // 디버깅용 로그
+
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/chats/chatRooms`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({
+            userIds: selectedUserIds, // 선택된 유저 ID 리스트
+            roomName: chatName, // 유저가 입력한 채팅방 이름
+            roomType: "GROUP", // 채팅방 유형 고정
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error("서버 응답 오류:", errorText); // 서버 응답 확인
+        throw new Error("채팅방 생성 중 오류가 발생했습니다.");
+      }
+
+      alert("채팅방이 생성되었습니다.");
+      setChatName(""); // 채팅방 이름 초기화
+      setSelectedUserIds([]); // 선택된 유저 초기화
+    } catch (error) {
+      console.error("채팅방 생성 실패:", error);
+      alert("채팅방 생성에 실패했습니다.");
+    }
+  };
+
+  if (loading) return <p>로딩 중...</p>;
+  if (error) return <p>{error}</p>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-6">채팅 시스템</h1>
+      <div className="grid grid-cols-3 gap-4">
+        {/* 왼쪽: 유저 리스트 */}
+        <div className="border-r p-4">
+          <h2 className="text-xl font-bold mb-4">유저 리스트</h2>
+          <ul className="space-y-2">
+            {users.map((user) => (
+              <li key={user.id} className="flex items-center">
+                <input
+                  type="checkbox"
+                  checked={selectedUserIds.includes(user.id)}
+                  onChange={() => toggleUserSelection(user.id)}
+                  className="mr-2"
+                />
+                <span>{user.name}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-4">
+            <input
+              type="text"
+              value={chatName}
+              onChange={(e) => setChatName(e.target.value)}
+              placeholder="채팅방 이름 입력"
+              className="border p-2 w-full mb-2"
+            />
+            <button
+              onClick={createChatRoom}
+              className="bg-blue-500 text-white px-4 py-2 rounded w-full"
+            >
+              채팅방 생성
+            </button>
+          </div>
+        </div>
+
+        {/* 중앙: 채팅방 리스트 */}
+        <div>
+          <ChatRoomList
+            onSelectRoom={(roomId) => setSelectedRoomId(roomId)} // 선택된 채팅방 ID 설정
+            client={client} // WebSocket 클라이언트 전달
+            loginUserId={loginUser.id} // 로그인 유저 ID 전달
+            roomType="GROUP" // GROUP 타입 채팅방 조회
+          />
+        </div>
+
+        {/* 오른쪽: 채팅 화면 */}
+        <div>
+          {selectedRoomId ? (
+            <Chat
+              roomId={selectedRoomId}
+              client={client}
+              loginUserId={loginUser.id}
+            />
+          ) : (
+            <p>채팅방을 선택하세요.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatPage;

--- a/frontend/src/app/chat/user/page.tsx
+++ b/frontend/src/app/chat/user/page.tsx
@@ -45,7 +45,7 @@ const ChatPage = () => {
             onSelectRoom={(roomId) => setSelectedRoomId(roomId)} // 선택된 채팅방 ID 설정
             client={client} // WebSocket 클라이언트 전달
             loginUserId={loginUser.id} // 로그인 유저 ID 전달
-            roomType="ONE_TO_ONE" // SUPPORT 타입 채팅방 조회
+            roomType="SUPPORT" // SUPPORT 타입 채팅방 조회
           />
         </div>
         <div>

--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -76,7 +76,7 @@ const Chat: React.FC<Props> = ({ roomId, client, loginUserId }) => {
       (message: Message) => {
         const response = JSON.parse(message.body); // 서버에서 발행된 메시지 파싱
         const receivedMessage: ChatResponseDto = response.data; // ApiResponse의 data 필드 추출
-
+        console.log("수신된 메시지:", response); // 디버깅용 로그
         setMessages((prevMessages) => [...prevMessages, receivedMessage]); // 메시지 추가
       }
     );
@@ -85,6 +85,15 @@ const Chat: React.FC<Props> = ({ roomId, client, loginUserId }) => {
       subscription.unsubscribe(); // 컴포넌트 언마운트 시 구독 해제
     };
   }, [roomId, client]);
+
+  //채팅방 나가기
+  const handleLeaveChatRoom = async () => {
+    try {
+      await leaveChatRoom(client, roomId, loginUserId);
+    } catch (error) {
+      console.error("채팅방 나가기 실패:", error);
+    }
+  };
 
   // 메시지 전송
   const sendMessage = () => {
@@ -126,7 +135,7 @@ const Chat: React.FC<Props> = ({ roomId, client, loginUserId }) => {
           </button>
           <button
             className="bg-red-500 text-white px-4 py-2 rounded"
-            onClick={() => leaveChatRoom(client, roomId, loginUserId)} // 나가기 로직 호출
+            onClick={handleLeaveChatRoom}
           >
             채팅방 나가기
           </button>

--- a/frontend/src/components/chat/ChatRoomList.tsx
+++ b/frontend/src/components/chat/ChatRoomList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Client, Message } from "@stomp/stompjs";
-import { leaveChatRoom } from "../../utils/leaveChatRoom"; // 나가기 로직 임포트
+import { Client } from "@stomp/stompjs";
+import { leaveChatRoom } from "../../utils/leaveChatRoom";
 
 interface ChatRoom {
   id: number;
@@ -12,7 +12,7 @@ interface Props {
   onSelectRoom: (roomId: number) => void; // 선택된 채팅방 ID를 부모 컴포넌트로 전달
   client: Client | null; // WebSocket 클라이언트
   loginUserId: number; // 현재 로그인한 유저 ID
-  roomType: string; // 채팅방 타입 (ONE_TO_ONE, SUPPORT 등)
+  roomType: string; // 채팅방 타입 (GROUP, ONE_TO_ONE 등)
 }
 
 const ChatRoomList: React.FC<Props> = ({
@@ -88,10 +88,12 @@ const ChatRoomList: React.FC<Props> = ({
 
   useEffect(() => {
     // 모든 채팅방의 상대방 이름 가져오기
-    chatRooms.forEach((room) => {
-      fetchOpponentName(room.id);
-    });
-  }, [chatRooms]);
+    if (roomType !== "GROUP") {
+      chatRooms.forEach((room) => {
+        fetchOpponentName(room.id);
+      });
+    }
+  }, [chatRooms, roomType]);
 
   useEffect(() => {
     const subscriptions: { [key: number]: boolean } = {};
@@ -174,14 +176,17 @@ const ChatRoomList: React.FC<Props> = ({
       <h2 className="text-xl font-bold mb-4">채팅방 리스트</h2>
       <ul className="space-y-2">
         {chatRooms.map((room) => {
-          const opponentName = opponentNames[room.id] || "로딩중.."; // 상대방 이름 또는 로딩 중 표시
+          const displayName =
+            roomType === "GROUP"
+              ? room.roomName // GROUP 타입일 경우 채팅방 이름
+              : opponentNames[room.id] || "로딩중.."; // 다른 타입일 경우 상대방 이름
 
           return (
             <li
               key={room.id}
               className="flex justify-between items-center border p-2 rounded"
             >
-              <span>{opponentName}</span>
+              <span>{displayName}</span>
               <div className="flex gap-2">
                 <button
                   className="bg-green-500 text-white px-4 py-2 rounded"

--- a/frontend/src/components/chat/ChatRoomList.tsx
+++ b/frontend/src/components/chat/ChatRoomList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Client } from "@stomp/stompjs";
+import { Client, Message } from "@stomp/stompjs";
 import { leaveChatRoom } from "../../utils/leaveChatRoom"; // 나가기 로직 임포트
 
 interface ChatRoom {
@@ -92,6 +92,21 @@ const ChatRoomList: React.FC<Props> = ({
       fetchOpponentName(room.id);
     });
   }, [chatRooms]);
+
+  useEffect(() => {
+    const subscriptions: { [key: number]: boolean } = {};
+
+    if (client && client.connected) {
+      chatRooms.forEach((room) => {
+        if (!subscriptions[room.id]) {
+          client.subscribe(`/sub/chat/${room.id}`, (message) => {
+            console.log(`채팅방 ${room.id}에서 메시지 수신:`, message.body);
+          });
+          subscriptions[room.id] = true; // 구독 상태 저장
+        }
+      });
+    }
+  }, [client, chatRooms]);
 
   const validateAndEnterRoom = async (roomId: number) => {
     try {

--- a/frontend/src/utils/leaveChatRoom.ts
+++ b/frontend/src/utils/leaveChatRoom.ts
@@ -44,6 +44,8 @@ export const leaveChatRoom = async (
 
     console.log("채팅방 나가기 성공");
     alert("채팅방을 나갔습니다.");
+    //window.location.href = "/chat/user"; // 채팅방 목록 등 다른 화면으로 이동
+
     window.location.reload(); // 새로고침
   } catch (error) {
     console.error("채팅방 나가기 실패:", error);

--- a/frontend/src/utils/leaveChatRoom.ts
+++ b/frontend/src/utils/leaveChatRoom.ts
@@ -15,7 +15,7 @@ export const leaveChatRoom = async (
     type: "LEAVE",
     userId: userId,
     roomId: roomId,
-    message: "퇴장", // 퇴장 메시지
+    message: "퇴장", // 메시지 내용은 null
   };
 
   client.publish({
@@ -43,7 +43,6 @@ export const leaveChatRoom = async (
     }
 
     console.log("채팅방 나가기 성공");
-
     alert("채팅방을 나갔습니다.");
     window.location.reload(); // 새로고침
   } catch (error) {

--- a/frontend/src/utils/leaveChatRoom.ts
+++ b/frontend/src/utils/leaveChatRoom.ts
@@ -15,7 +15,7 @@ export const leaveChatRoom = async (
     type: "LEAVE",
     userId: userId,
     roomId: roomId,
-    message: null, // 메시지 내용은 null
+    message: "퇴장", // 퇴장 메시지
   };
 
   client.publish({
@@ -43,6 +43,7 @@ export const leaveChatRoom = async (
     }
 
     console.log("채팅방 나가기 성공");
+
     alert("채팅방을 나갔습니다.");
     window.location.reload(); // 새로고침
   } catch (error) {


### PR DESCRIPTION
## 📒 개요

단체 채팅 기능 구현 완료 

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#126 
> closed #Issue_number

<br>

## 🛠️ 작업사항

- 관리 페이지에 속한 유저 조회 기능 추가
- 선택한 유저들과 단체 채팅방 생성 기능 구현
- 단체 채팅방 조회 및 나가기 기능 구현
- 유저가 채팅방 나갈 시 Redis에 삭제 예약 키 저장 (1분 TTL)
- 해당 채팅방의 유저가 모두 나간 경우만 삭제 예약 진행
- Redis Set에 삭제 대상 채팅방 ID 추가
- 스케줄러가 TTL 확인 후 DB에서 채팅방 삭제

<br>

## 📸 스크린샷(선택)


<img width="1137" alt="스크린샷 2025-05-18 오후 8 14 42" src="https://github.com/user-attachments/assets/3019e6fb-a998-4b8a-a3f1-3facb9953bcd" />


