### PR TITLE
[ back / feat ] 135 : redis를 사용하여 refreshtoken 검증 후 재발급 RTR 적용 

### DIFF
--- a/backend/src/main/java/com/example/backend/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/example/backend/exception/ExceptionCode.java
@@ -46,6 +46,7 @@ public enum ExceptionCode {
     //회원가입 예외 처리
     ALREADY_HAS_EMAIL(409,"이미 존재하는 이메일입니다."),
     ALREADY_HAS_PHONE_NUMBER(409,"이미 존재하는 전화번호입니다."),
+    INVALID_REFRESH_TOKEN(401, "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요."),
 
     //S3 예외 처리
     S3_DELETE_ERROR(404, "이미지를 삭제할 수 없습니다."),

--- a/backend/src/main/java/com/example/backend/redis/RedisConfig.java
+++ b/backend/src/main/java/com/example/backend/redis/RedisConfig.java
@@ -21,7 +21,6 @@ public class RedisConfig {
     private int redisPort;
 
 
-
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(redisHost, redisPort); // localhost:6379 기본 설정

--- a/backend/src/main/java/com/example/backend/redis/RedisService.java
+++ b/backend/src/main/java/com/example/backend/redis/RedisService.java
@@ -65,4 +65,20 @@ public class RedisService {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
+    // refreshToken 저장 (7일 TTL)
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        saveData("refresh:" + userId, refreshToken, Duration.ofDays(7));
+    }
+
+    // refreshToken 조회
+    public String getRefreshToken(Long userId) {
+        return getData("refresh:" + userId);
+    }
+
+    // refreshToken 삭제
+    public void deleteRefreshToken(Long userId) {
+        deleteData("refresh:" + userId);
+    }
+
+
 }

--- a/backend/src/main/java/com/example/backend/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/security/config/SecurityConfigJuseyo.java
@@ -3,8 +3,10 @@ package com.example.backend.security.config;
 
 
 
+import com.example.backend.redis.RedisService;
 import com.example.backend.security.jwt.filter.JwtAuthenticationFilter;
 import com.example.backend.security.jwt.filter.UserStatusCheckFilter;
+import com.example.backend.security.jwt.service.TokenService;
 import com.example.backend.security.jwt.util.JwtTokenizer;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ public class SecurityConfigJuseyo {
 
     private final JwtTokenizer jwtTokenizer;
     private final UserStatusCheckFilter userStatusCheckFilter;
+    private final RedisService redisService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -80,7 +83,7 @@ public class SecurityConfigJuseyo {
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(userStatusCheckFilter, UsernamePasswordAuthenticationFilter.class) // UserStatusCheckFilter 추가
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenizer), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenizer,redisService), UsernamePasswordAuthenticationFilter.class)
 
                 .formLogin(form -> form.disable())
                 .sessionManagement(session -> session

--- a/backend/src/main/java/com/example/backend/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/backend/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,8 +1,12 @@
 package com.example.backend.security.jwt.filter;
 
 
+import com.example.backend.exception.BusinessLogicException;
+import com.example.backend.exception.ExceptionCode;
 import com.example.backend.exception.JwtExceptionCode;
+import com.example.backend.redis.RedisService;
 import com.example.backend.security.dto.CustomUserDetails;
+import com.example.backend.security.jwt.service.TokenService;
 import com.example.backend.security.jwt.token.JwtAuthenticationToken;
 import com.example.backend.security.jwt.util.JwtTokenizer;
 import io.jsonwebtoken.Claims;
@@ -33,6 +37,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenizer jwtTokenizer;
+    private final RedisService redisService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -41,12 +46,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessToken = getAccessToken(request);
         String refreshToken = getRefreshToken(request);
 
+
         if (accessToken == null && refreshToken == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
         if (accessToken == null && refreshToken != null) {
+            log.info("refreshToken 검사 filter !  " + refreshToken);
+            validRefreshToken(refreshToken);
             log.info("refreshToken 33 " + refreshToken);
             if (StringUtils.hasText(refreshToken) && jwtTokenizer.validateRefreshToken(refreshToken)) {
                 try {
@@ -62,6 +70,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
             }
         }
+
+
+
+
 
         if (StringUtils.hasText(accessToken)) {
             try {
@@ -185,22 +197,44 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String name = claims.get("username", String.class);
         List<String> roles = claims.get("roles", List.class);
 
-        log.info("역할 이름 확인!!!!" + roles.get(0));
+        long maxAgeAccessInSeconds = jwtTokenizer.accessTokenExpirationMinutes / 1000;
+        long maxAgeRefreshInSeconds = jwtTokenizer.refreshTokenExpirationMinutes / 1000;
 
         String newAccessToken = jwtTokenizer.createAccessToken(userId, email, name, roles.get(0));
+        String newRefreshToken = jwtTokenizer.createRefreshToken(userId, email, name, roles.get(0));
 
         // 쿠키로 재전송
         Cookie newAccessTokenCookie = new Cookie("accessToken", newAccessToken);
         newAccessTokenCookie.setHttpOnly(true);
         newAccessTokenCookie.setPath("/");
-        newAccessTokenCookie.setMaxAge(60 * 30); // 30분
+        newAccessTokenCookie.setMaxAge(Math.toIntExact(maxAgeAccessInSeconds)); // 30분
         response.addCookie(newAccessTokenCookie);
+
+        // 쿠키로 재전송
+        Cookie newRefreshTokenCookie = new Cookie("refreshToken", newRefreshToken);
+        newAccessTokenCookie.setHttpOnly(true);
+        newAccessTokenCookie.setPath("/");
+        newAccessTokenCookie.setMaxAge(Math.toIntExact(maxAgeRefreshInSeconds)); // 30분
+        response.addCookie(newRefreshTokenCookie);
+
+        redisService.saveRefreshToken(userId,newRefreshToken);
 
         // SecurityContext 갱신
         Authentication authentication = getAuthentication(newAccessToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
-
     }
+
+    public void validRefreshToken(String refreshToken) {
+        Claims claims = jwtTokenizer.parseRefreshToken(refreshToken);
+
+        Long userId = claims.get("userId", Long.class);
+        String savedRefreshToken = redisService.getRefreshToken(userId);
+
+        if (savedRefreshToken == null || !refreshToken.equals(savedRefreshToken)) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
 
 
 

--- a/backend/src/main/java/com/example/backend/security/jwt/service/TokenService.java
+++ b/backend/src/main/java/com/example/backend/security/jwt/service/TokenService.java
@@ -5,6 +5,7 @@ package com.example.backend.security.jwt.service;
 import com.example.backend.enums.RoleType;
 import com.example.backend.exception.BusinessLogicException;
 import com.example.backend.exception.ExceptionCode;
+import com.example.backend.redis.RedisService;
 import com.example.backend.role.entity.Role;
 import com.example.backend.role.repository.RoleRepository;
 import com.example.backend.security.jwt.util.JwtTokenizer;
@@ -26,6 +27,7 @@ public class TokenService {
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final JwtTokenizer jwtTokenizer;
+    private final RedisService redisService;
 
 
     public String getTokenFromRequest() {
@@ -108,6 +110,7 @@ public class TokenService {
         refreshTokenCookie.setHttpOnly(true);
         refreshTokenCookie.setPath("/");
         refreshTokenCookie.setMaxAge(Math.toIntExact(maxAgeRefreshInSeconds));
+        redisService.saveRefreshToken(user.getId(),refreshToken);
 
 
         httpServletResponse.addCookie(accessTokenCookie);

--- a/backend/src/main/java/com/example/backend/security/jwt/util/JwtTokenizer.java
+++ b/backend/src/main/java/com/example/backend/security/jwt/util/JwtTokenizer.java
@@ -2,14 +2,18 @@ package com.example.backend.security.jwt.util;
 
 import com.example.backend.exception.BusinessLogicException;
 import com.example.backend.exception.ExceptionCode;
+import com.example.backend.redis.RedisService;
+import com.example.backend.user.entity.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -201,7 +205,6 @@ public class JwtTokenizer {
             }
         }
     }
-
 
 
 


### PR DESCRIPTION
## 📒 개요

redis를 사용하여 refreshtoken 검증 후 재발급 RTR 적용 

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->

#135 
> closed #Issue_number

<br>

## 🛠️ 작업사항

- Redis에 RefreshToken 저장 (refresh:{userId} 형태, TTL 7일)
- RefreshToken 검증 시 Redis에 저장된 값과 비교
- 일치하지 않으면 INVALID_REFRESH_TOKEN 예외 발생
- 토큰 재발급 시 새로운 RefreshToken 생성 및 Redis에 덮어쓰기 (RTR 적용)

<br>

## 📸 스크린샷(선택)
