### PR TITLE
[ back / feat ] : 핸드폰 번호 인증 구현완료 유효 시간 3분

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -86,6 +86,9 @@ dependencies {
     //S3 의존성
     implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 
+    //누리고
+    implementation("net.nurigo:sdk:4.2.7") // 누리고 SDK
+
 }
 
 

--- a/backend/src/main/java/com/example/backend/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/security/config/SecurityConfigJuseyo.java
@@ -44,6 +44,8 @@ public class SecurityConfigJuseyo {
                                 "/v3/api-docs/**"
                         ).permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/biz/check").permitAll()
+                        //핸드폰
+                        .requestMatchers(HttpMethod.POST, "/api/v1/sms/**").permitAll()
                         //채팅
                         .requestMatchers( "/api/v1/users/chat/list/**","/api/v1/users/chat/**").hasAnyRole("MANAGER", "USER","ADMIN")
                         //회원

--- a/backend/src/main/java/com/example/backend/sms/controller/SmsController.java
+++ b/backend/src/main/java/com/example/backend/sms/controller/SmsController.java
@@ -1,0 +1,65 @@
+package com.example.backend.sms.controller;
+
+import com.example.backend.sms.dto.PhoneVerificationRequest;
+import com.example.backend.sms.dto.SmsRequestDto;
+import com.example.backend.sms.service.SmsService;
+import com.example.backend.user.dto.request.EmailRequestDto;
+import com.example.backend.user.dto.request.EmailVerificationRequest;
+import com.example.backend.utils.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sms")
+@Tag(name = "SMS 인증 API", description = "휴대폰 문자 인증번호 전송 및 인증")
+public class SmsController {
+
+    private final SmsService smsService;
+
+    @PostMapping("/certificationNumber")
+    @Operation(
+            summary = "핸드폰으로 인증번호 전송",
+            description = "사용자의 휴대폰 번호로 인증번호를 전송합니다."
+    )
+    public ResponseEntity sendCertificationNumberPhone(@Valid @RequestBody SmsRequestDto smsRequestDto) {
+        smsService.sendVerificationCode(smsRequestDto.getPhoneNumber().replaceAll("-", ""));
+        return new ResponseEntity<>(
+                ApiResponse.of(HttpStatus.OK.value(), "핸드폰으로 인증번호 전송 완료 "),
+                HttpStatus.OK
+        );
+    }
+
+
+
+    @PostMapping("/verification")
+    @Operation(
+            summary = "핸드폰 인증번호 검증",
+            description = "사용자가 입력한 인증코드를 확인하여 핸드폰 인증을 진행합니다. 인증번호가 유효한 경우 인증이 완료됩니다."
+    )
+    public ResponseEntity phoneCertificationNumberValid(@Valid @RequestBody PhoneVerificationRequest phoneVerificationRequest) {
+        boolean valid = smsService.verifiedCode(phoneVerificationRequest.getPhoneNumber().replaceAll("-", ""), phoneVerificationRequest.getAuthCode());
+
+        if (valid) {
+            return new ResponseEntity<>(
+                    ApiResponse.of(HttpStatus.OK.value(), "핸드폰 번호 인증 성공 (인증 번호 인증 성공) "),
+                    HttpStatus.OK
+            );
+        } else {
+            return new ResponseEntity<>(
+                    ApiResponse.of(HttpStatus.UNAUTHORIZED.value(), "핸드폰 번호 인증 실패 (인증 번호 인증 실패) "),
+                    HttpStatus.UNAUTHORIZED
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/example/backend/sms/dto/PhoneVerificationRequest.java
+++ b/backend/src/main/java/com/example/backend/sms/dto/PhoneVerificationRequest.java
@@ -1,0 +1,22 @@
+package com.example.backend.sms.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PhoneVerificationRequest {
+
+
+    @NotBlank
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "전화번호 형식은 010-1234-5678이어야 합니다.")
+    private String phoneNumber;
+
+    @NotBlank
+    private String authCode;
+
+}

--- a/backend/src/main/java/com/example/backend/sms/dto/SmsRequestDto.java
+++ b/backend/src/main/java/com/example/backend/sms/dto/SmsRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.backend.sms.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SmsRequestDto {
+
+    @NotBlank
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "전화번호 형식은 010-1234-5678이어야 합니다.")
+    private String phoneNumber;
+
+}

--- a/backend/src/main/java/com/example/backend/sms/service/SmsService.java
+++ b/backend/src/main/java/com/example/backend/sms/service/SmsService.java
@@ -1,0 +1,78 @@
+package com.example.backend.sms.service;
+
+import com.example.backend.redis.RedisService;
+import com.example.backend.utils.CreateRandomNumber;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.exception.NurigoEmptyResponseException;
+import net.nurigo.sdk.message.exception.NurigoMessageNotReceivedException;
+import net.nurigo.sdk.message.exception.NurigoUnknownException;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import net.nurigo.sdk.message.model.Message;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SmsService {
+
+    private final RedisService redisService;
+
+    @Value("${nurigo.api-key}")
+    private String apiKey;
+
+    @Value("${nurigo.secret-key}")
+    private String secretKey;
+
+    @Value("${nurigo.sender-phone}")
+    private String senderPhone;
+
+    @Value("${nurigo.auth-code-expiration-millis}")
+    private long authNurigoCodeExpirationMillis;
+
+    private static final String AUTH_CODE_PREFIX = "certification:phone:";
+
+    private DefaultMessageService messageService;
+
+    @PostConstruct
+    public void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, secretKey, "https://api.coolsms.co.kr");
+    }
+    public void sendVerificationCode(String phoneNumber) {
+        String code = CreateRandomNumber.randomNumber();
+
+
+        redisService.saveData(AUTH_CODE_PREFIX + phoneNumber,
+                code, Duration.ofMillis(authNurigoCodeExpirationMillis));
+
+        Message message = new Message();
+        message.setFrom(senderPhone);
+        message.setTo(phoneNumber);
+        message.setText("[Juseyo] 인증번호 [" + code + "] 를 입력해주세요.");
+
+        try {
+            messageService.send(message);
+        } catch (NurigoMessageNotReceivedException e) {
+            throw new RuntimeException("문자 전송 실패: 메시지를 받지 못함", e);
+        } catch (NurigoEmptyResponseException e) {
+            throw new RuntimeException("문자 전송 실패: 응답 없음", e);
+        } catch (NurigoUnknownException e) {
+            throw new  RuntimeException("문자 전송 실패: 알 수 없는 오류", e);
+        }
+    }
+
+    public boolean verifiedCode(String phone, String authCode) {
+        String redisAuthCode = redisService.getData(AUTH_CODE_PREFIX + phone);
+        return redisAuthCode != null && redisAuthCode.equals(authCode);
+    }
+
+
+}

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -4,6 +4,7 @@ package com.example.backend.user.controller;
 import com.example.backend.managementDashboard.service.ManagementDashboardService;
 import com.example.backend.role.entity.Role;
 import com.example.backend.security.jwt.service.TokenService;
+import com.example.backend.sms.dto.SmsRequestDto;
 import com.example.backend.user.dto.request.*;
 import com.example.backend.user.dto.response.ApproveUserListForInitialManagerResponseDto;
 import com.example.backend.user.dto.response.UserListResponseDto;
@@ -415,6 +416,7 @@ public class UserController {
         );
     }
 
+
     @GetMapping("/token")
     @Operation(
             summary = "토큰으로 유저 조회하기 ",
@@ -427,6 +429,22 @@ public class UserController {
                 HttpStatus.OK
         );
     }
+
+    @GetMapping("/email/phone")
+    @Operation(
+            summary = "핸드폰 번호로 이메일 조회하기",
+            description = "핸드폰 번호로 이메일 조회, 핸드폰 번호로 인증된 사용자만 사용 가능"
+    )
+    public ResponseEntity getEmailByPhone(@Valid @RequestBody SmsRequestDto smsRequestDto) {
+        String response = userService.findEmailByPhone(
+                smsRequestDto.getPhoneNumber());
+        return new ResponseEntity<>(
+                ApiResponse.of(HttpStatus.OK.value(), "핸드폰 번호로 이메일 조회 성공 ",response),
+                HttpStatus.OK
+        );
+    }
+
+
 
 
 

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -540,6 +540,14 @@ public class UserService {
         return findById(tokenService.getIdFromToken());
     }
 
+    public String findEmailByPhone(String phone){
+        User user = findByPhoneNumber(phone);
+
+        return user.getEmail();
+    }
+
+
+
 
     public Page<User> getUserListForChat(String managementDashboardName, Pageable pageable) {
         ManagementDashboard managementDashboard = findByPageName(managementDashboardName);


### PR DESCRIPTION
## 📒 개요

누리고 API를 활용하여 휴대폰 인증 기능을 구현
인증번호는 문자(SMS)로 전송되며, Redis를 통해 인증번호의 유효시간을 관리
<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#156 
> closed #Issue_number

<br>

## 🛠️ 작업사항

**누리고 API 연동을 통한 문자 인증번호 전송, 사용자 입력 전화번호 전처리**

- 010-1234-5678 형식으로 입력받은 번호에서 하이픈(-)을 제거하여 01012345678 형식으로 처리

**인증번호 전송**

- 처리된 번호로 인증번호를 SMS로 전송

**Redis에 인증정보 저장**

- 키: PREFIX + 전화번호
- 값: 인증번호
- TTL: 3분 (180,000ms)

**인증 요청 처리**

- 사용자가 전송한 인증번호와 Redis에 저장된 인증번호를 비교

- 일치할 경우 인증 성공


<br>

## 📸 스크린샷(선택)
번호는 개인정보라 가렸습니다. 

<img width="1117" alt="스크린샷 2025-05-20 오후 6 59 03" src="https://github.com/user-attachments/assets/52fabaca-f6fd-45a2-b46c-15a35050be8f" />
<img width="1117" alt="스크린샷 2025-05-20 오후 6 58 54" src="https://github.com/user-attachments/assets/c2d3595b-5cf0-4b40-b7f1-18e7feb47c2e" />
<img width="260" alt="스크린샷 2025-05-20 오후 6 58 30" src="https://github.com/user-attachments/assets/4f4c09de-7c8f-4c35-83e5-8b1975ea4fd9" />

![IMG_3676](https://github.com/user-attachments/assets/eab71406-aa16-476e-9622-0fbc9af281b3)
