### PR TITLE
Front/feat/226 핸드폰 번호로 이메일 찾기 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
@@ -438,7 +438,7 @@ public class UserController {
         );
     }
 
-    @GetMapping("/email/phone")
+    @PostMapping("/emails/phone")
     @Operation(
             summary = "핸드폰 번호로 이메일 조회하기",
             description = "핸드폰 번호로 이메일 조회, 핸드폰 번호로 인증된 사용자만 사용 가능"
@@ -451,8 +451,6 @@ public class UserController {
                 HttpStatus.OK
         );
     }
-
-
 
 
 

--- a/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
@@ -502,6 +502,7 @@ public class UserController {
     }
 
 
+
     @DeleteMapping
     @Operation(
             summary = "유저 삭제(manager, user)  구현  ",

--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -21,7 +21,7 @@ export default function ClientLayout({
   const isAuthPage =
     pathname.startsWith("/login") ||
     pathname.startsWith("/signup") ||
-    pathname.startsWith("/find/");
+    pathname.startsWith("/find");
   const isRootPage = pathname === "/";
   const shouldHideNav = isAuthPage || isRootPage;
 

--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -176,6 +176,11 @@ export default function ClientLayout({
     // 로그인 여부 확인 중일 때는 리다이렉트하지 않음
     if (isLoginUserPending) return;
 
+    if (isLogin && isAuthPage) {
+      alert("이미 로그인된 사용자 입니다.");
+      router.push("/");
+    }
+
     // 로그인되지 않은 사용자가 인증이 필요한 페이지에 접근하려고 할 때 리다이렉트
     if (!isLogin && !isAuthPage && !isRootPage) {
       alert("로그인이 필요한 페이지입니다.");
@@ -220,9 +225,13 @@ export default function ClientLayout({
             )}
 
             {/* 메인 콘텐츠 */}
-            <div 
+            <div
               className={`flex-1 min-h-screen transition-all duration-300 ease-in-out ${
-                !shouldHideNav ? (sidebarCollapsed ? 'ml-[80px]' : 'ml-[280px]') : ''
+                !shouldHideNav
+                  ? sidebarCollapsed
+                    ? "ml-[80px]"
+                    : "ml-[280px]"
+                  : ""
               }`}
             >
               {children}

--- a/frontend/src/app/find/email/page.tsx
+++ b/frontend/src/app/find/email/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  checkPhoneDuplication,
+  sendPhoneAuthCode,
+  verifyPhoneAuthCode,
+} from "@/utils/phoneValidation";
+
+export default function FindEmailPage() {
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [phoneAuthCode, setPhoneAuthCode] = useState("");
+  const [phoneAuthCodeSent, setPhoneAuthCodeSent] = useState(false);
+  const [phoneTimer, setPhoneTimer] = useState(180); // 3분 타이머
+  const [isPhoneVerified, setIsPhoneVerified] = useState(false);
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPhoneDuplicate, setIsPhoneDuplicate] = useState<boolean | null>(
+    null
+  ); // 핸드폰 번호 중복 여부
+
+  // 핸드폰 번호 중복 확인
+  const handleCheckPhoneDuplication = async () => {
+    setError("");
+    if (!/^010-\d{4}-\d{4}$/.test(phoneNumber)) {
+      setError("유효한 핸드폰 번호 형식을 입력해주세요. (예: 010-1234-5678)");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const isDuplicate = await checkPhoneDuplication(phoneNumber);
+      setIsPhoneDuplicate(isDuplicate);
+
+      if (!isDuplicate) {
+        setError("존재하지 않는 핸드폰 번호입니다.");
+      }
+    } catch (error) {
+      setError("핸드폰 번호 확인 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 인증번호 요청
+  const handleSendPhoneAuthCode = async () => {
+    setError("");
+
+    try {
+      setIsLoading(true);
+      const success = await sendPhoneAuthCode(phoneNumber);
+
+      if (success) {
+        setPhoneAuthCodeSent(true);
+        setPhoneTimer(180); // 타이머 초기화
+        startTimer();
+      } else {
+        setError("인증번호 전송에 실패했습니다.");
+      }
+    } catch (error) {
+      setError("인증번호 요청 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 인증번호 확인
+  const handleVerifyPhoneAuthCode = async () => {
+    setError("");
+    if (!phoneAuthCode.trim()) {
+      setError("인증번호를 입력해주세요.");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const success = await verifyPhoneAuthCode(phoneNumber, phoneAuthCode);
+
+      if (success) {
+        setIsPhoneVerified(true);
+      } else {
+        setError("인증번호 확인에 실패했습니다.");
+      }
+    } catch (error) {
+      setError("인증번호 확인 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 타이머 시작
+  const startTimer = () => {
+    const timer = setInterval(() => {
+      setPhoneTimer((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          setPhoneAuthCodeSent(false); // 타이머 종료 시 인증번호 입력 비활성화
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setEmail("");
+
+    if (!isPhoneVerified) {
+      setError("전화번호 인증이 완료되지 않았습니다.");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+      const response = await fetch(`${API_URL}/api/v1/users/find-email`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phoneNumber }),
+      });
+
+      if (!response.ok) {
+        throw new Error("이메일 찾기에 실패했습니다.");
+      }
+
+      const data = await response.json();
+      setEmail(data.email);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white flex items-center justify-center px-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-3xl shadow-2xl w-full max-w-md p-8 space-y-6"
+      >
+        <div className="text-center">
+          <h2 className="text-3xl font-bold text-[#0047AB]">이메일 찾기</h2>
+          <p className="text-gray-500 mt-2 text-sm">
+            전화번호를 입력하고 인증을 완료하면 이메일을 찾을 수 있습니다.
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 text-red-600 border border-red-300 px-4 py-2 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        {email && (
+          <div className="bg-green-50 text-green-700 border border-green-300 px-4 py-2 rounded-lg text-sm">
+            찾은 이메일: <strong>{email}</strong>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1">
+            핸드폰 번호
+          </label>
+          <input
+            type="text"
+            value={phoneNumber}
+            onChange={(e) => setPhoneNumber(e.target.value)}
+            placeholder="예: 010-1234-5678"
+            className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button
+            type="button"
+            onClick={handleCheckPhoneDuplication}
+            className="w-full mt-2 py-2 bg-[#0047AB] text-white font-semibold rounded-xl hover:bg-blue-800 transition-all disabled:opacity-60"
+            disabled={isLoading}
+          >
+            {isLoading ? "확인 중..." : "핸드폰 번호 확인"}
+          </button>
+        </div>
+
+        {isPhoneDuplicate === false && (
+          <div className="bg-red-50 text-red-600 border border-red-300 px-4 py-2 rounded-lg text-sm mt-4">
+            존재하지 않는 핸드폰 번호입니다.
+          </div>
+        )}
+
+        {isPhoneDuplicate && (
+          <>
+            {phoneAuthCodeSent && (
+              <div className="mt-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  인증번호 입력
+                </label>
+                <div className="flex items-center">
+                  <input
+                    type="text"
+                    value={phoneAuthCode}
+                    onChange={(e) => setPhoneAuthCode(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:border-[#0047AB] focus:outline-none"
+                    placeholder="인증번호를 입력하세요"
+                    disabled={phoneTimer === 0}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleVerifyPhoneAuthCode}
+                    className="ml-3 px-3 py-3 rounded-lg text-white text-sm bg-[#0047AB] hover:bg-blue-800 flex min-w-[100px] whitespace-nowrap items-center justify-center"
+                    disabled={isLoading}
+                  >
+                    인증
+                  </button>
+                </div>
+                <p className="text-xs text-gray-500 mt-1">
+                  남은 시간: {Math.floor(phoneTimer / 60)}:
+                  {String(phoneTimer % 60).padStart(2, "0")}
+                </p>
+              </div>
+            )}
+
+            {!isPhoneVerified && (
+              <button
+                type="button"
+                onClick={handleSendPhoneAuthCode}
+                className="w-full py-3 bg-[#0047AB] text-white font-semibold rounded-xl hover:bg-blue-800 transition-all disabled:opacity-60"
+                disabled={isLoading || phoneAuthCodeSent}
+              >
+                {isLoading ? "전송 중..." : "인증번호 받기"}
+              </button>
+            )}
+          </>
+        )}
+
+        <button
+          type="submit"
+          className="w-full py-3 bg-[#0047AB] text-white font-semibold rounded-xl hover:bg-blue-800 transition-all disabled:opacity-60"
+          disabled={isLoading || !isPhoneVerified}
+        >
+          {isLoading ? "찾는 중..." : "이메일 찾기"}
+        </button>
+        <div className="bg-gray-50 px-8 py-4 text-center">
+          <div className="flex justify-center space-x-6">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center text-[#0047AB] font-medium hover:underline text-base mr-4"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-1"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+              </svg>
+              홈으로 돌아가기
+            </Link>
+
+            <Link
+              href="/login/type"
+              className="inline-flex items-center justify-center text-[#0047AB] font-medium hover:underline text-base"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-1"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z" />
+              </svg>
+              로그인 하기
+            </Link>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/find/password/page.tsx
+++ b/frontend/src/app/find/password/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+export default function FindEmailPage() {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setMessage("");
+
+    if (!email.trim()) {
+      setError("이메일을 입력해주세요.");
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError("유효한 이메일 형식을 입력해주세요.");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+      const response = await fetch(
+        `${API_URL}/api/v1/users/find-password/email`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "비밀번호 찾기에 실패했습니다.");
+      }
+
+      setMessage("임시 비밀번호가 전송되었습니다. 이메일을 확인해주세요.");
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white flex items-center justify-center px-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-3xl shadow-2xl w-full max-w-md p-8 space-y-6"
+      >
+        <div className="text-center">
+          <h2 className="text-3xl font-bold text-[#0047AB]">비밀번호 찾기</h2>
+          <p className="text-gray-500 mt-2 text-sm">
+            이메일을 입력하여 임시 비밀번호를 전송받을 수 있습니다.
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+            {error}
+          </div>
+        )}
+        {message && (
+          <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+            {message}
+          </div>
+        )}
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            이메일 주소
+          </label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500"
+            placeholder="이메일을 입력하세요"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="w-full py-3 bg-[#0047AB] text-white font-semibold rounded-xl hover:bg-blue-800 transition-all disabled:opacity-60"
+          disabled={isLoading}
+        >
+          {isLoading ? "찾는 중..." : "이메일 찾기"}
+        </button>
+        <div className="bg-gray-50 px-8 py-4 text-center">
+          <div className="flex justify-center space-x-6">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center text-[#0047AB] font-medium hover:underline text-base mr-4"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-1"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+              </svg>
+              홈으로 돌아가기
+            </Link>
+
+            <Link
+              href="/login/type"
+              className="inline-flex items-center justify-center text-[#0047AB] font-medium hover:underline text-base"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-1"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z" />
+              </svg>
+              로그인 하기
+            </Link>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -175,13 +175,16 @@ export default function LoginPage() {
             {isLoading ? "로그인 중..." : "로그인"}
           </button>
           <div className="mt-4 text-right">
-            <a href="#" className="text-[#0047AB] hover:underline">
+            <Link href="/find/email" className="text-[#0047AB] hover:underline">
               이메일 찾기
-            </a>
+            </Link>
             /
-            <a href="#" className="text-[#0047AB] hover:underline">
+            <Link
+              href="/find/password"
+              className="text-[#0047AB] hover:underline"
+            >
               비밀번호 찾기
-            </a>
+            </Link>
           </div>
         </div>
         <div className="bg-gray-50 px-8 py-4 text-center border-t border-gray-200">

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -174,9 +174,13 @@ export default function LoginPage() {
           >
             {isLoading ? "로그인 중..." : "로그인"}
           </button>
-          <div className="mt-4 text-center">
+          <div className="mt-4 text-right">
             <a href="#" className="text-[#0047AB] hover:underline">
-              비밀번호를 잊으셨나요?
+              이메일 찾기
+            </a>
+            /
+            <a href="#" className="text-[#0047AB] hover:underline">
+              비밀번호 찾기
             </a>
           </div>
         </div>


### PR DESCRIPTION
## 📒 개요

핸드폰 번호로 이메일 찾기 구현 완료 

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#226 
> closed #Issue_number

<br>

## 🛠️ 작업사항
- 핸드폰 번호 입력 & 인증 요청
사용자가 핸드폰 번호를 입력하고 인증번호를 요청합니다.
서버는 인증번호를 발송하고 DB에 해당 번호와 함께 저장합니다.
- 인증번호 확인
사용자가 받은 인증번호를 입력하고 확인 버튼을 누르면,
서버에서 인증번호 일치 여부 및 유효시간을 검증합니다.
- 이메일 조회 요청
인증에 성공한 경우, 사용자는 핸드폰 번호로 이메일을 조회할 수 있습니다.
서버는 해당 핸드폰 번호로 가입된 이메일을 반환합니다.
- 이메일 결과 모달 표시
이메일을 성공적으로 찾은 경우, 모달 창을 통해 이메일을 사용자에게 표시합니다.

- 예외 처리 
인증번호 불일치 또는 시간 만료 시 오류 메시지 출력
등록되지 않은 번호에 대해 이메일이 없음을 안내
<br>

## 📸 스크린샷(선택)
![KakaoTalk_Photo_2025-05-24-01-50-15 002](https://github.com/user-attachments/assets/fdc500e9-2913-4bff-8400-cc0772f42c34)
![KakaoTalk_Photo_2025-05-24-01-50-15 001](https://github.com/user-attachments/assets/9f3c951e-9056-416a-94c3-b1e4bea4404a)

