### PR TITLE
[ front / feat ] 236 : 일반 유저 회원가입 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/department/controller/DepartmentController.java
+++ b/backend/src/main/java/com/example/backend/domain/department/controller/DepartmentController.java
@@ -18,11 +18,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import retrofit2.http.Path;
 
 
 @RestController
@@ -107,5 +112,24 @@ public class DepartmentController {
         departmentService.deleteDepartment(id);
         return ResponseEntity.noContent().build();  // 204 No Content 상태 반환
     }
+
+    @GetMapping("/management")
+    @Operation(
+            summary = "관리 페이지에 속한 부서 페이지 조회",
+            description = "회원가입 시, 관리페이지에 존재하는 부서를 조회할때 사용."
+    )
+    public ResponseEntity<Page<DepartmentResponseDTO>> getAllDepartmentsByManagement(
+            @RequestParam String name,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").ascending());
+        Page<Department> departments = departmentService.findAllDepartmentsByManagement(name, pageable);
+
+        Page<DepartmentResponseDTO> response = departments.map(DepartmentResponseDTO::fromEntity);
+
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/backend/src/main/java/com/example/backend/domain/department/controller/DepartmentController.java
+++ b/backend/src/main/java/com/example/backend/domain/department/controller/DepartmentController.java
@@ -113,7 +113,7 @@ public class DepartmentController {
         return ResponseEntity.noContent().build();  // 204 No Content 상태 반환
     }
 
-    @GetMapping("/g")
+    @GetMapping("/management")
     @Operation(
             summary = "관리 페이지에 속한 부서 페이지 조회",
             description = "회원가입 시, 관리페이지에 존재하는 부서를 조회할때 사용."

--- a/backend/src/main/java/com/example/backend/domain/department/controller/DepartmentController.java
+++ b/backend/src/main/java/com/example/backend/domain/department/controller/DepartmentController.java
@@ -113,7 +113,7 @@ public class DepartmentController {
         return ResponseEntity.noContent().build();  // 204 No Content 상태 반환
     }
 
-    @GetMapping("/management")
+    @GetMapping("/g")
     @Operation(
             summary = "관리 페이지에 속한 부서 페이지 조회",
             description = "회원가입 시, 관리페이지에 존재하는 부서를 조회할때 사용."

--- a/backend/src/main/java/com/example/backend/domain/department/repository/DepartmentRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/department/repository/DepartmentRepository.java
@@ -1,11 +1,18 @@
 package com.example.backend.domain.department.repository;
 
 import com.example.backend.domain.department.entity.Department;
+import com.example.backend.domain.managementDashboard.entity.ManagementDashboard;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DepartmentRepository extends JpaRepository<Department,Long> {
     Optional<Department> findByManagementDashboardIdAndName(Long managementDashboardId, String name);
+
+    Page<Department> findByManagementDashboard(ManagementDashboard managementDashboard, Pageable pageable);
+
 
     boolean existsByName(String name);
 }

--- a/backend/src/main/java/com/example/backend/domain/department/service/DepartmentService.java
+++ b/backend/src/main/java/com/example/backend/domain/department/service/DepartmentService.java
@@ -10,6 +10,8 @@ import com.example.backend.global.exception.BusinessLogicException;
 import com.example.backend.global.exception.ExceptionCode;
 import com.example.backend.domain.managementDashboard.entity.ManagementDashboard;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -72,6 +74,20 @@ public class DepartmentService {
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.DEPARTMENT_NOT_FOUND));
 
         departmentRepository.delete(department);
+    }
+
+
+    public Page<Department> findAllDepartmentsByManagement(String name, Pageable pageable) {
+        ManagementDashboard managementDashboard = managementDashboardRepository.findByName(name)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MANAGEMENT_DASHBOARD_NOT_FOUND));
+
+        Page<Department> departments = departmentRepository.findByManagementDashboard(managementDashboard, pageable);
+
+        if (departments.isEmpty()) {
+            throw new BusinessLogicException(ExceptionCode.DEPARTMENT_NOT_FOUND);
+        }
+
+        return departments;
     }
 
 

--- a/backend/src/main/java/com/example/backend/domain/managementDashboard/controller/ManagementController.java
+++ b/backend/src/main/java/com/example/backend/domain/managementDashboard/controller/ManagementController.java
@@ -115,14 +115,14 @@ public class ManagementController {
             summary = "관리 페이지 존재하는지 검증 ",
             description = "관리 페이지 이름을 입력으로 받고, 검증할 수 있습니다."
     )
-    @PostMapping("/validation/{name}")
-    public ResponseEntity<ApiResponse<Boolean>> validationName(@RequestParam @Valid String name){
+    @PostMapping("/validation")
+    public ResponseEntity<ApiResponse<Boolean>> validationName(@RequestParam @Valid String name) {
         boolean response = managementDashboardService.isValidName(name);
-
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), "관리 페이지 검증 성공", response),
                 HttpStatus.OK
         );
     }
+
 
 }

--- a/backend/src/main/java/com/example/backend/domain/managementDashboard/controller/ManagementController.java
+++ b/backend/src/main/java/com/example/backend/domain/managementDashboard/controller/ManagementController.java
@@ -12,11 +12,13 @@ import com.example.backend.global.security.jwt.service.TokenService;
 import com.example.backend.domain.user.dto.response.UserSearchResponseDto;
 import com.example.backend.domain.user.entity.User;
 import com.example.backend.domain.user.service.UserService;
+import com.example.backend.global.utils.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -107,6 +109,20 @@ public class ManagementController {
                 .toList();
 
         return ResponseEntity.ok(managers);
+    }
+
+    @Operation(
+            summary = "관리 페이지 존재하는지 검증 ",
+            description = "관리 페이지 이름을 입력으로 받고, 검증할 수 있습니다."
+    )
+    @PostMapping("/validation/{name}")
+    public ResponseEntity<ApiResponse<Boolean>> validationName(@RequestParam @Valid String name){
+        boolean response = managementDashboardService.isValidName(name);
+
+        return new ResponseEntity<>(
+                ApiResponse.of(HttpStatus.OK.value(), "관리 페이지 검증 성공", response),
+                HttpStatus.OK
+        );
     }
 
 }

--- a/backend/src/main/java/com/example/backend/domain/managementDashboard/service/ManagementDashboardService.java
+++ b/backend/src/main/java/com/example/backend/domain/managementDashboard/service/ManagementDashboardService.java
@@ -179,4 +179,8 @@ public class ManagementDashboardService {
                 .map(UserSearchResponseDto::fromEntity)
                 .toList();
     }
+
+    public boolean isValidName(String name){
+        return managementRepository.findByName(name).isPresent();
+    }
 }

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -59,6 +59,9 @@ public class SecurityConfigJuseyo {
                         .requestMatchers(HttpMethod.GET, "/api/v1/departments/**").hasAnyRole("MANAGER", "USER")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/departments/**").hasRole("MANAGER")
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/departments/**").hasRole("MANAGER")
+                        //관리 페이지
+                        .requestMatchers(HttpMethod.POST,"/api/v1/management/validation/**").permitAll()
+
 
                         // 알림 관련 설정
                         .requestMatchers(HttpMethod.POST, "/api/v1/notifications/**").authenticated()

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -55,11 +55,13 @@ public class SecurityConfigJuseyo {
                         //비품
                         .requestMatchers(HttpMethod.PUT, "/api/v1/items/**").hasRole("MANAGER") // 비품수정은 매니저만 가능
                         //부서
+                        .requestMatchers(HttpMethod.GET,  "/api/v1/departments/management/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/departments/**").hasRole("MANAGER")
                         .requestMatchers(HttpMethod.GET, "/api/v1/departments/**").hasAnyRole("MANAGER", "USER")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/departments/**").hasRole("MANAGER")
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/departments/**").hasRole("MANAGER")
-                        .requestMatchers(HttpMethod.GET, "/api/v1/departments/management/**").permitAll()
+
+
                         //관리 페이지
                         .requestMatchers(HttpMethod.POST,"/api/v1/management/validation/**").permitAll()
 

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -59,7 +59,7 @@ public class SecurityConfigJuseyo {
                         .requestMatchers(HttpMethod.GET, "/api/v1/departments/**").hasAnyRole("MANAGER", "USER")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/departments/**").hasRole("MANAGER")
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/departments/**").hasRole("MANAGER")
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/departments/management/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/departments/management/**").permitAll()
                         //관리 페이지
                         .requestMatchers(HttpMethod.POST,"/api/v1/management/validation/**").permitAll()
 

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -59,6 +59,7 @@ public class SecurityConfigJuseyo {
                         .requestMatchers(HttpMethod.GET, "/api/v1/departments/**").hasAnyRole("MANAGER", "USER")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/departments/**").hasRole("MANAGER")
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/departments/**").hasRole("MANAGER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/departments/management/**").permitAll()
                         //관리 페이지
                         .requestMatchers(HttpMethod.POST,"/api/v1/management/validation/**").permitAll()
 

--- a/frontend/src/app/signup/info/page.tsx
+++ b/frontend/src/app/signup/info/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function ManagementPage() {
+  const [managementPageName, setManagementPageName] = useState("");
+  const [departmentName, setDepartmentName] = useState("");
+  const [departments, setDepartments] = useState<string[]>([]); // 부서 목록
+  const [isManagementPageValid, setIsManagementPageValid] = useState(false); // 관리 페이지 검증 상태
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+
+  // 관리 페이지 검증 및 부서 조회
+  const validateManagementPage = async () => {
+    setError("");
+    setMessage("");
+    setDepartments([]);
+
+    if (!managementPageName.trim()) {
+      setError("관리 페이지 이름을 입력해주세요.");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+      // 관리 페이지 검증
+      const validationResponse = await fetch(
+        `${API_URL}/api/v1/management/validation?name=${managementPageName}`,
+        {
+          method: "POST",
+        }
+      );
+
+      if (!validationResponse.ok) {
+        throw new Error("관리 페이지 검증에 실패했습니다.");
+      }
+
+      const validationData = await validationResponse.json();
+      if (!validationData.data) {
+        setIsManagementPageValid(false);
+        setError("존재하지 않는 관리 페이지입니다.");
+        return;
+      }
+
+      setIsManagementPageValid(true);
+      setMessage("존재하는 관리 페이지입니다.");
+
+      // 부서 조회
+      const departmentResponse = await fetch(
+        `${API_URL}/api/v1/departments/management?name=${managementPageName}&page=0&size=5`,
+        {
+          method: "GET",
+        }
+      );
+
+      if (!departmentResponse.ok) {
+        throw new Error("부서 조회에 실패했습니다.");
+      }
+
+      const departmentData = await departmentResponse.json();
+      const departmentList = departmentData.content.map(
+        (department: { name: string }) => department.name
+      );
+      setDepartments(departmentList);
+    } catch (error) {
+      setError("관리 페이지 검증 및 부서 조회 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 폼 제출
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!managementPageName.trim() || !departmentName.trim()) {
+      alert("모든 필드를 입력해주세요.");
+      return;
+    }
+
+    // 로컬 스토리지에 저장
+    localStorage.setItem("managementPageName", managementPageName);
+    localStorage.setItem("departmentName", departmentName);
+
+    // 회원가입 페이지로 이동
+    router.push("/signup/member");
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white flex items-center justify-center px-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-3xl shadow-2xl w-full max-w-md p-8 space-y-6"
+      >
+        <div className="text-center">
+          <h2 className="text-3xl font-bold text-[#0047AB]">
+            관리 페이지 설정
+          </h2>
+          <p className="text-gray-500 mt-2 text-sm">
+            관리 페이지 이름을 입력하고 검증을 완료하세요.
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+            {error}
+          </div>
+        )}
+        {message && (
+          <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+            {message}
+          </div>
+        )}
+
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            관리 페이지 이름
+          </label>
+          <input
+            type="text"
+            value={managementPageName}
+            onChange={(e) => setManagementPageName(e.target.value)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500"
+            placeholder="관리 페이지 이름을 입력하세요"
+          />
+          <button
+            type="button"
+            onClick={validateManagementPage}
+            className="w-full mt-2 py-2 bg-[#0047AB] text-white font-semibold rounded-xl hover:bg-blue-800 transition-all disabled:opacity-60"
+            disabled={isLoading}
+          >
+            {isLoading ? "검증 중..." : "관리 페이지 검증"}
+          </button>
+        </div>
+
+        {isManagementPageValid && (
+          <>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                부서 선택
+              </label>
+              <select
+                value={departmentName}
+                onChange={(e) => setDepartmentName(e.target.value)}
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500"
+              >
+                <option value="">부서를 선택하세요</option>
+                {departments.map((department) => (
+                  <option key={department} value={department}>
+                    {department}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <button
+              type="submit"
+              className="w-full py-3 bg-[#0047AB] text-white font-semibold rounded-xl hover:bg-blue-800 transition-all"
+            >
+              다음
+            </button>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/signup/info/page.tsx
+++ b/frontend/src/app/signup/info/page.tsx
@@ -167,7 +167,7 @@ export default function ManagementPage() {
 
             <button
               type="submit"
-              className="w-full py-3 bg-[#0047AB] text-white font-semibold rounded-xl hover:bg-blue-800 transition-all"
+              className="w-full py-2 bg-[#0047AB] text-white font-semibold rounded-xl hover:bg-blue-800 transition-all disabled:opacity-60"
             >
               다음
             </button>
@@ -202,7 +202,7 @@ export default function ManagementPage() {
               >
                 <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z" />
               </svg>
-              회원가입
+              회원가입하기
             </button>
           </div>
         </div>

--- a/frontend/src/app/signup/info/page.tsx
+++ b/frontend/src/app/signup/info/page.tsx
@@ -202,7 +202,7 @@ export default function ManagementPage() {
               >
                 <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z" />
               </svg>
-              회원가입하기
+              회원가입
             </button>
           </div>
         </div>

--- a/frontend/src/app/signup/info/page.tsx
+++ b/frontend/src/app/signup/info/page.tsx
@@ -173,7 +173,7 @@ export default function ManagementPage() {
             </button>
           </>
         )}
-        <div className="bg-gray-50 px-8 py-4 text-center border-t border-gray-200">
+        <div className="bg-gray-50 mt-15 px-8 py-3 text-center border-t border-gray-200">
           <div className="flex justify-center space-x-6">
             <Link
               href="/"

--- a/frontend/src/app/signup/info/page.tsx
+++ b/frontend/src/app/signup/info/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 
 export default function ManagementPage() {
@@ -12,6 +12,12 @@ export default function ManagementPage() {
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+
+  // 페이지 로드 시 로컬 스토리지 값 제거
+  useEffect(() => {
+    localStorage.removeItem("managementPageName");
+    localStorage.removeItem("departmentName");
+  }, []);
 
   // 관리 페이지 검증 및 부서 조회
   const validateManagementPage = async () => {

--- a/frontend/src/app/signup/info/page.tsx
+++ b/frontend/src/app/signup/info/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export default function ManagementPage() {
   const [managementPageName, setManagementPageName] = useState("");
@@ -172,6 +173,39 @@ export default function ManagementPage() {
             </button>
           </>
         )}
+        <div className="bg-gray-50 px-8 py-4 text-center border-t border-gray-200">
+          <div className="flex justify-center space-x-6">
+            <Link
+              href="/"
+              className="flex items-center justify-center px-6 py-2 border border-[#0047AB] text-[#0047AB] rounded-lg font-medium hover:bg-blue-50 transition-colors text-base"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-1"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+              </svg>
+              홈으로
+            </Link>
+            <button
+              type="button"
+              onClick={() => router.push("/signup")}
+              className="flex items-center justify-center px-6 py-2 bg-[#0047AB] text-white rounded-lg font-medium hover:bg-blue-800 transition-colors text-base"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-1"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z" />
+              </svg>
+              회원가입하기
+            </button>
+          </div>
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/app/signup/member/page.tsx
+++ b/frontend/src/app/signup/member/page.tsx
@@ -360,7 +360,7 @@ export default function InitialSignupPage() {
                   >
                     {authCodeSent
                       ? "인증"
-                      : isLoading
+                      : isEmailLoading
                       ? "로딩중..."
                       : "인증번호 받기"}
                   </button>

--- a/frontend/src/app/signup/member/page.tsx
+++ b/frontend/src/app/signup/member/page.tsx
@@ -70,15 +70,21 @@ export default function InitialSignupPage() {
 
   useEffect(() => {
     // 로컬 스토리지에서 관리 페이지 이름과 부서 이름 가져오기
-    const managementPageName = localStorage.getItem("managementPageName") || "";
-    const departmentName = localStorage.getItem("departmentName") || "";
+    const managementPageName = localStorage.getItem("managementPageName");
+    const departmentName = localStorage.getItem("departmentName");
+
+    if (!managementPageName || !departmentName) {
+      // 관리 페이지 이름과 부서 이름이 없으면 /signup/info로 리다이렉트
+      router.push("/signup/info");
+      return;
+    }
 
     setFormData((prev) => ({
       ...prev,
       managementPageName,
       departmentName,
     }));
-  }, []);
+  }, [router]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const { name, value } = e.target;
@@ -245,6 +251,8 @@ export default function InitialSignupPage() {
       }
 
       alert("회원가입이 완료되었습니다.");
+      localStorage.removeItem("managementPageName");
+      localStorage.removeItem("departmentName");
       router.push("/");
     } catch (error) {
       alert(

--- a/frontend/src/app/signup/member/page.tsx
+++ b/frontend/src/app/signup/member/page.tsx
@@ -93,11 +93,13 @@ export default function InitialSignupPage() {
       const isDuplicated = await checkEmailDuplication(formData.email);
       setIsEmailChecked(true);
       setIsEmailDuplicated(isDuplicated);
-      alert(
-        isDuplicated
-          ? "이미 사용 중인 이메일입니다."
-          : "사용 가능한 이메일입니다. 인증번호를 발급받아주세요."
-      );
+
+      if (isDuplicated) {
+        alert("이미 사용 중인 이메일입니다. 다시 확인해주세요.");
+        setIsEmailChecked(false); // 다시 중복 확인 가능하도록 상태 초기화
+      } else {
+        alert("사용 가능한 이메일입니다. 인증번호를 발급받아주세요.");
+      }
     } catch {
       alert("중복 확인 중 오류가 발생했습니다.");
     }
@@ -147,11 +149,12 @@ export default function InitialSignupPage() {
       const isDuplicated = await checkPhoneDuplication(formData.phoneNumber);
       setIsPhoneChecked(true);
       setIsPhoneDuplicated(isDuplicated);
-      alert(
-        isDuplicated
-          ? "이미 사용 중인 전화번호입니다."
-          : "사용 가능한 전화번호입니다. 인증번호를 발급받아주세요."
-      );
+      if (isDuplicated) {
+        alert("이미 사용 중인 전화번호입니다. 다시 확인해주세요.");
+        setIsPhoneChecked(false); // 다시 중복 확인 가능하도록 상태 초기화
+      } else {
+        alert("사용 가능한 전화번호입니다. 인증번호를 발급받아주세요.");
+      }
     } catch {
       alert("전화번호 중복 확인 중 오류가 발생했습니다.");
     }
@@ -308,32 +311,41 @@ export default function InitialSignupPage() {
             <label className="block text-sm font-medium text-gray-700 mb-1">
               이메일
             </label>
-            <div className="mb-4 flex items-center">
-              <input
-                type="email"
-                name="email"
-                value={formData.email}
-                onChange={handleChange}
-                disabled={isEmailVerified}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:border-[#0047AB] focus:outline-none"
-                placeholder="이메일을 입력하세요"
-              />
-              <button
-                type="button"
-                onClick={handleEmailCheck}
-                disabled={isEmailVerified || isEmailChecked}
-                className={`ml-3 px-7 py-2.5 rounded-lg text-white text-sm min-w-[100px] whitespace-nowrap flex items-center justify-center ${
-                  isEmailVerified || isEmailChecked
-                    ? "bg-gray-400"
-                    : "bg-[#0047AB] hover:bg-blue-800"
-                }`}
-              >
-                {isEmailVerified
-                  ? "완료됨"
-                  : isEmailChecked
-                  ? "중복 확인 완료"
-                  : "중복 확인"}
-              </button>
+            <div className="mb-4 w-full">
+              <div className="flex items-center">
+                <input
+                  type="email"
+                  name="email"
+                  value={formData.email}
+                  onChange={handleChange}
+                  disabled={isEmailVerified || isEmailChecked} // 중복 확인 완료 시 비활성화
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:border-[#0047AB] focus:outline-none"
+                  placeholder="이메일을 입력하세요"
+                />
+                <button
+                  type="button"
+                  onClick={handleEmailCheck}
+                  disabled={isEmailVerified || isEmailChecked}
+                  className={`ml-3 px-7 py-2.5 rounded-lg text-white text-sm min-w-[100px] whitespace-nowrap flex items-center justify-center ${
+                    isEmailVerified || isEmailChecked
+                      ? "bg-gray-400"
+                      : "bg-[#0047AB] hover:bg-blue-800"
+                  }`}
+                >
+                  {isEmailVerified
+                    ? "완료됨"
+                    : isEmailChecked
+                    ? "중복 확인 완료"
+                    : "중복 확인"}
+                </button>
+              </div>
+
+              {/* ✅ input 바로 아래 메시지 (margin-top만 살짝 줌) */}
+              {isEmailVerified && (
+                <p className="text-sm mt-1 text-[#0047AB]">
+                  이메일 인증이 완료되었습니다.
+                </p>
+              )}
             </div>
 
             {/* 인증번호 입력 */}
@@ -374,13 +386,6 @@ export default function InitialSignupPage() {
               </div>
             )}
 
-            {/* 인증 완료 메시지 */}
-            {isEmailVerified && (
-              <p className="text-sm mt-2" style={{ color: "#0047AB" }}>
-                이메일 인증이 완료되었습니다.
-              </p>
-            )}
-
             {/* 전화번호 */}
             <div className="mb-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -414,6 +419,13 @@ export default function InitialSignupPage() {
                 </button>
               </div>
 
+              {/* ✅ 전화번호 인증 완료 메시지 - input 바로 아래에 오도록 */}
+              {isPhoneVerified && (
+                <p className="text-sm mt-1 text-[#0047AB]">
+                  전화번호 인증이 완료되었습니다.
+                </p>
+              )}
+
               {/* 인증번호 입력 */}
               {isPhoneChecked && !isPhoneDuplicated && !isPhoneVerified && (
                 <div className="mt-4">
@@ -440,7 +452,7 @@ export default function InitialSignupPage() {
                     >
                       {phoneAuthCodeSent
                         ? "인증"
-                        : isLoading
+                        : isPhoneLoading
                         ? "로딩중..."
                         : "인증번호 받기"}
                     </button>
@@ -452,13 +464,6 @@ export default function InitialSignupPage() {
                     </p>
                   )}
                 </div>
-              )}
-
-              {/* 인증 완료 메시지 */}
-              {isPhoneVerified && (
-                <p className="text-sm mt-2" style={{ color: "#0047AB" }}>
-                  전화번호 인증이 완료되었습니다.
-                </p>
               )}
             </div>
 


### PR DESCRIPTION
## 📒 개요

일반 유저 회원가입 구현

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->

> closed #Issue_number

<br>

## 🛠️ 작업사항

**백엔드 구현** 
- 관리페이지 이름으로 존재하는 부서 조회 api 추가
- 관리 페이지 이름 존재하는지 식별하는 api 추가
- 두개 api 접근 권한 permitall 설정

**프론트 구현** 
- /signup/info 페이지 생성:
관리 페이지 이름과 부서 이름을 입력받는 페이지 추가.
입력된 값을 로컬 스토리지에 저장.

- 관리 페이지 검증 기능 구현:
/api/v1/management/validation API를 호출하여 관리 페이지 이름 검증.
검증 성공 시 "존재하는 관리 페이지입니다." 메시지 표시.

- 부서 조회 기능 구현:
/api/v1/departments/management API를 호출하여 관리 페이지에 속한 부서 목록 조회.
조회된 부서를 드롭다운


- /signup/member
일반 유저 회원가입 구현, 핸드폰 인증, 이메일 인증 완료해야 회원가입 가능 


- /signup/member 페이지 접근 제한
관리페이지, 부서 이름 입력 완료해야 접근 가능 

- UI 개선 
버튼 상태 및 로딩 중 메시지 추가.
"홈으로" 및 "회원가입하기" 버튼 추가

<br>

## 📸 스크린샷(선택)

<img width="553" alt="스크린샷 2025-05-25 오후 7 11 31" src="https://github.com/user-attachments/assets/f61e3612-4ff0-451e-abeb-555600cafc01" />
<img width="553" alt="스크린샷 2025-05-25 오후 7 11 49" src="https://github.com/user-attachments/assets/629ab1ac-21fe-4395-b421-01f5fe321450" />



