### PR TITLE
[ front / feat ] 239 : 로그인 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/user/dto/request/UserLoginRequestDto.java
+++ b/backend/src/main/java/com/example/backend/domain/user/dto/request/UserLoginRequestDto.java
@@ -18,7 +18,12 @@ public class UserLoginRequestDto {
     private String email;
 
     @NotEmpty
+    @Pattern(
+            regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*\\W).{8,20}$",
+            message = "비밀번호는 영문자, 숫자, 특수문자를 포함한 8~20자리."
+    )
     private String password;
+
 
 
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -15,6 +15,19 @@ export default function LoginPage() {
   const handleBackToSelection = () => {
     router.push("/login/type");
   };
+
+  // 이메일 형식 검증
+  const isValidEmailFormat = (email: string) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  // 비밀번호 형식 검증
+  const isValidPasswordFormat = (password: string) => {
+    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*\W).{8,20}$/;
+    return passwordRegex.test(password);
+  };
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
@@ -23,8 +36,21 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    // 입력값 검증
     if (!formData.email.trim() || !formData.password.trim()) {
-      setError("이메일과 비밀번호를 모두 입력해주세요.");
+      setError("입력 필드를 모두 입력해주세요.");
+      return;
+    }
+
+    if (!isValidEmailFormat(formData.email)) {
+      setError("이메일 형식에 맞지 않습니다.");
+      return;
+    }
+
+    if (!isValidPasswordFormat(formData.password)) {
+      setError(
+        "비밀번호는 영문자, 숫자, 특수문자를 포함한 8~20자리여야 합니다."
+      );
       return;
     }
 
@@ -49,7 +75,8 @@ export default function LoginPage() {
         throw new Error(errorData.message || "로그인에 실패했습니다.");
       }
 
-      router.push("/dashboard"); // 로그인 성공 시 대시보드로 이동
+      alert("로그인되었습니다.");
+      window.location.href = "/";
     } catch (error) {
       setError(error instanceof Error ? error.message : "로그인 중 오류 발생");
     } finally {
@@ -89,7 +116,7 @@ export default function LoginPage() {
       >
         <div className="bg-[#0047AB] text-white px-8 py-6 text-center">
           <h2 className="text-2xl font-bold">
-            {loginType === "manager" ? "매니저 로그인" : "회원 로그인"}
+            {loginType === "MANAGER" ? "매니저 로그인" : "회원 로그인"}
           </h2>
           <p className="text-base mt-2 opacity-80">
             계정 정보를 입력하여 로그인하세요.
@@ -135,7 +162,8 @@ export default function LoginPage() {
             </svg>
           </div>
         </div>
-        <div className="px-8 py-8">
+
+        <div className="bg-white px-8 py-8">
           {error && (
             <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4 text-base">
               {error}


### PR DESCRIPTION
## 📒 개요

로그인 기능 구현 완료

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->

> closed #Issue_number

<br>

## 🛠️ 작업사항

- 회원/매니저 별 로그인 기능 구현:
/api/v1/users/login API를 통해 로그인 요청 처리.
이메일과 비밀번호 형식 검증 추가:
이메일 형식이 맞지 않으면 "이메일 형식에 맞지 않습니다." 알림 표시.
비밀번호는 영문자, 숫자, 특수문자를 포함한 8~20자리여야 함.

- 입력값 검증 및 에러 처리:
입력 필드가 비어 있으면 "입력 필드를 모두 입력해주세요." 알림 표시.
서버 응답에 따른 에러 메시지 표시.

- 로그인 성공 시 리다이렉트:
로그인 성공 시 [window.location.href = "/"] 를 통해 홈 화면으로 이동하며 새로고침.

- UI 개선
로그인 유형(회원/매니저)에 따라 동적 헤더 표시.
"유형 선택으로 돌아가기", "이메일 찾기", "비밀번호 찾기" 링크 추가.
"홈으로" 및 "회원가입하기" 버튼 추가.

<br>

## 📸 스크린샷(선택)
<img width="556" alt="스크린샷 2025-05-25 오후 7 34 37" src="https://github.com/user-attachments/assets/e98efa05-fc0c-40ab-90c6-dd86df18ffab" />

<img width="556" alt="스크린샷 2025-05-25 오후 7 34 48" src="https://github.com/user-attachments/assets/9638e082-1144-4dc1-bdba-852797cadf78" />

