### PR TITLE
[ front / feat ] 241 : 회원 승인, 거부, 요청 조회 페이지 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
@@ -46,7 +46,6 @@ public class UserController {
     private final ManagementDashboardService managementDashboardService;
 
 
-
     @PostMapping("/signup")
     @Operation(
             summary = "회원 가입 (일반 사용자)",
@@ -55,7 +54,7 @@ public class UserController {
     public ResponseEntity signupUser(@Valid @RequestBody UserSignRequestDto userSignRequestDto) {
         userService.createUser(userSignRequestDto);
 
-        return new ResponseEntity<>("일반 회원 생성 성공",HttpStatus.CREATED);
+        return new ResponseEntity<>("일반 회원 생성 성공", HttpStatus.CREATED);
     }
 
 
@@ -65,7 +64,8 @@ public class UserController {
             summary = "회원 가입 (최초 매니저)",
             description = "최초 매니저(Initial Manager)의 회원가입을 처리합니다."
     )
-    public ResponseEntity signupInitialManager(@Valid @RequestBody InitialManagerSignupRequestDto initialManagerSignupRequestDto) {
+    public ResponseEntity signupInitialManager(
+            @Valid @RequestBody InitialManagerSignupRequestDto initialManagerSignupRequestDto) {
         userService.createInitialManager(initialManagerSignupRequestDto);
         return new ResponseEntity<>("매니저 생성 성공", HttpStatus.CREATED);
 
@@ -118,7 +118,8 @@ public class UserController {
             description = "로그인한 유저의 이름을 수정할 수 있습니다. "
     )
     public ResponseEntity updateName(@Valid @RequestBody UserPatchRequestDto.changeName changeNameDto) {
-        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(userService.updateUserName(changeNameDto));
+        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(
+                userService.updateUserName(changeNameDto));
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), " 이름 수정 성공 ", userProfileResponseDto),
                 HttpStatus.OK
@@ -131,7 +132,8 @@ public class UserController {
             description = "로그인한 유저의 이메일을 수정할 수 있습니다. "
     )
     public ResponseEntity updateEmail(@Valid @RequestBody UserPatchRequestDto.changeEmail changeEmailDto) {
-        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(userService.updateUserEmail(changeEmailDto));
+        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(
+                userService.updateUserEmail(changeEmailDto));
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), " 이메일 수정 성공 ", userProfileResponseDto),
                 HttpStatus.OK
@@ -144,10 +146,11 @@ public class UserController {
             description = "로그인한 유저의 비밀번호를 수정할 수 있습니다. "
     )
     public ResponseEntity updatePassword(@Valid @RequestBody UserPatchRequestDto.changePassword changePassword) {
-        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(userService.updatePassword(changePassword));
+        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(
+                userService.updatePassword(changePassword));
 
         return new ResponseEntity<>(
-                ApiResponse.of(HttpStatus.OK.value(), " 비밀번호 수정 성공 ",userProfileResponseDto),
+                ApiResponse.of(HttpStatus.OK.value(), " 비밀번호 수정 성공 ", userProfileResponseDto),
                 HttpStatus.OK
         );
     }
@@ -157,9 +160,11 @@ public class UserController {
             summary = "유저 핸드폰 번호 수정  ",
             description = "로그인한 유저의 핸드폰 번호를 수정할 수 있습니다. "
     )
-    public ResponseEntity updatePhoneNumber(@Valid @RequestBody UserPatchRequestDto.changePhoneNumber changePhoneNumberDto) {
+    public ResponseEntity updatePhoneNumber(
+            @Valid @RequestBody UserPatchRequestDto.changePhoneNumber changePhoneNumberDto) {
 
-        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(userService.updateUserPhoneNumber(changePhoneNumberDto));
+        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(
+                userService.updateUserPhoneNumber(changePhoneNumberDto));
 
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), "핸드폰 번호 수정 성공", userProfileResponseDto),
@@ -173,9 +178,10 @@ public class UserController {
             summary = "유저 부서 수정  ",
             description = "로그인한 유저의 부서를 수정할 수 있습니다. "
     )
-    public ResponseEntity updateDepartment(@PathVariable Long departmentId ) {
+    public ResponseEntity updateDepartment(@PathVariable Long departmentId) {
 
-        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(userService.updateUserDepartment(departmentId));
+        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto(
+                userService.updateUserDepartment(departmentId));
 
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), "핸드폰 번호 수정 성공", userProfileResponseDto),
@@ -183,8 +189,6 @@ public class UserController {
         );
 
     }
-
-
 
 
     @GetMapping("/approve")
@@ -246,11 +250,10 @@ public class UserController {
             description = "승인된 유저 리스트를 조회합니다."
     )
     public ResponseEntity<?> getChatUsers(@RequestParam String managementDashboardName,
-                                              @RequestParam(defaultValue = "1") int page,
-                                              @RequestParam(defaultValue = "10") int size) {
+                                          @RequestParam(defaultValue = "1") int page,
+                                          @RequestParam(defaultValue = "10") int size) {
         PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
-        Page<User> approveUser = userService.getUserListForChat(managementDashboardName,pageRequest)
-;
+        Page<User> approveUser = userService.getUserListForChat(managementDashboardName, pageRequest);
         Page<UserListResponseDto> userListResponse = approveUser.map(UserListResponseDto::new);
         return ResponseEntity.ok(ApiResponse.of(200, "승인된 유저 리스트 조회 성공", userListResponse));
     }
@@ -321,13 +324,15 @@ public class UserController {
             description = "해당 관리 페이지 사용이 거부된 매니저 리스트를 조회할 수 있습니다."
     )
     public ResponseEntity<?> getRejectManager(@RequestParam String managementDashboardName
-            ,@RequestParam(name = "page", defaultValue = "1") int page,
-                                           @RequestParam(name="size", defaultValue = "10") int size) {
+            , @RequestParam(name = "page", defaultValue = "1") int page,
+                                              @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Page<User> approveUserList = userService.getRejectManagerList(managementDashboardName,
-                PageRequest.of(page -1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+                PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
 
-        Page<ApproveUserListForInitialManagerResponseDto> responseList = approveUserList.map(ApproveUserListForInitialManagerResponseDto::new);;
+        Page<ApproveUserListForInitialManagerResponseDto> responseList = approveUserList.map(
+                ApproveUserListForInitialManagerResponseDto::new);
+        ;
 
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), "사용이 거부된 매니저 리스트 조회 성공", responseList),
@@ -342,13 +347,15 @@ public class UserController {
             description = "해당 관리 페이지 사용이 승인된 매니저 리스트를 조회할 수 있습니다."
     )
     public ResponseEntity<?> getApproveManager(@RequestParam String managementDashboardName
-            ,@RequestParam(name = "page", defaultValue = "1") int page,
-                                              @RequestParam(name="size", defaultValue = "10") int size) {
+            , @RequestParam(name = "page", defaultValue = "1") int page,
+                                               @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Page<User> approveUserList = userService.getApprovedManagerList(managementDashboardName,
-                PageRequest.of(page -1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+                PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
 
-        Page<ApproveUserListForInitialManagerResponseDto> responseList = approveUserList.map(ApproveUserListForInitialManagerResponseDto::new);;
+        Page<ApproveUserListForInitialManagerResponseDto> responseList = approveUserList.map(
+                ApproveUserListForInitialManagerResponseDto::new);
+        ;
 
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), "사용이 승인된 매니저 리스트 조회 성공", responseList),
@@ -363,13 +370,15 @@ public class UserController {
             description = "해당 관리 페이지 사용을 요청한 매니저 리스트를 조회할 수 있습니다."
     )
     public ResponseEntity<?> getRequestManager(@RequestParam String managementDashboardName
-            ,@RequestParam(name = "page", defaultValue = "1") int page,
-                                               @RequestParam(name="size", defaultValue = "10") int size) {
+            , @RequestParam(name = "page", defaultValue = "1") int page,
+                                               @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Page<User> approveUserList = userService.getRequestManagerList(managementDashboardName,
-                PageRequest.of(page -1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+                PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
 
-        Page<ApproveUserListForInitialManagerResponseDto> responseList = approveUserList.map(ApproveUserListForInitialManagerResponseDto::new);;
+        Page<ApproveUserListForInitialManagerResponseDto> responseList = approveUserList.map(
+                ApproveUserListForInitialManagerResponseDto::new);
+        ;
 
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), "사용을 요청한 매니저 리스트 조회 성공", responseList),
@@ -379,8 +388,6 @@ public class UserController {
     }
 
 
-
-
     @PostMapping("/emails/findPassword")
     @Operation(
             summary = "비밀번호 찾기",
@@ -388,7 +395,7 @@ public class UserController {
     )
     public ResponseEntity<?> findPassword(@Valid @RequestBody EmailRequestDto emailRequestDto) {
         // 비밀번호 찾기 로직을 수행하고, 해당 결과를 response로 반환
-       userService.findPasswordByEmail(emailRequestDto.getEmail());
+        userService.findPasswordByEmail(emailRequestDto.getEmail());
 
         return new ResponseEntity<>(
                 ApiResponse.of(HttpStatus.OK.value(), "임시 비밀번호 이메일 전송 완료"),
@@ -415,7 +422,8 @@ public class UserController {
             summary = "이메일 인증 확인",
             description = "사용자가 입력한 인증코드를 확인하여 이메일 인증을 진행합니다. 인증번호가 유효한 경우 인증이 완료됩니다."
     )
-    public ResponseEntity sendCertificationNumberValid(@Valid @RequestBody EmailVerificationRequest emailVerificationRequest) {
+    public ResponseEntity sendCertificationNumberValid(
+            @Valid @RequestBody EmailVerificationRequest emailVerificationRequest) {
         userService.verifyEmailCode(emailVerificationRequest);
 
         return new ResponseEntity<>(
@@ -433,7 +441,7 @@ public class UserController {
     public ResponseEntity sendCertificationNumberValid() {
         UserProfileResponseDto responseDto = new UserProfileResponseDto(userService.findUserByToken());
         return new ResponseEntity<>(
-                ApiResponse.of(HttpStatus.OK.value(), "토큰으로 사용자 조회 성공 ",responseDto),
+                ApiResponse.of(HttpStatus.OK.value(), "토큰으로 사용자 조회 성공 ", responseDto),
                 HttpStatus.OK
         );
     }
@@ -447,11 +455,10 @@ public class UserController {
         String response = userService.findEmailByPhone(
                 smsRequestDto.getPhoneNumber());
         return new ResponseEntity<>(
-                ApiResponse.of(HttpStatus.OK.value(), "핸드폰 번호로 이메일 조회 성공 ",response),
+                ApiResponse.of(HttpStatus.OK.value(), "핸드폰 번호로 이메일 조회 성공 ", response),
                 HttpStatus.OK
         );
     }
-
 
 
     @PostMapping("/login")
@@ -459,7 +466,7 @@ public class UserController {
             summary = "로그인",
             description = "로그인을 처리합니다."
     )
-    public ResponseEntity login(@RequestBody UserLoginRequestDto userLoginRequestDto){
+    public ResponseEntity login(@RequestBody UserLoginRequestDto userLoginRequestDto) {
         User user = userService.findByEmail(userLoginRequestDto.getEmail());
         //비밀번호 일치하는지 확인
         userService.validPassword(userLoginRequestDto.getPassword(), user.getPassword());
@@ -473,7 +480,7 @@ public class UserController {
             summary = "로그아웃",
             description = "로그아웃을 처리합니다."
     )
-    public ResponseEntity login(){
+    public ResponseEntity login() {
 
         Role role = tokenService.getRoleFromToken();
         String name = role.getRole().name();
@@ -488,7 +495,7 @@ public class UserController {
             summary = "admin 유저 삭제 구현  ",
             description = "admin 유저를 삭제할 수 있습니다.  "
     )
-    public ResponseEntity deleteAdmin( ) {
+    public ResponseEntity deleteAdmin() {
 
         userService.deleteAdmin();
 
@@ -500,13 +507,12 @@ public class UserController {
     }
 
 
-
     @DeleteMapping
     @Operation(
             summary = "유저 삭제(manager, user)  구현  ",
             description = "유저 삭제(manager, user)를 삭제할 수 있습니다.  "
     )
-    public ResponseEntity updateDepartment( ) {
+    public ResponseEntity updateDepartment() {
 
         userService.deleteUser();
 
@@ -515,4 +521,16 @@ public class UserController {
                 HttpStatus.OK
         );
     }
+
+    @GetMapping("/validation/initialManager")
+    @Operation(
+            summary = "현재 로그인된 매니저가 최초매니저인지 확인  ",
+            description = "현재 로그인된 매니저가 최초매니저인지 확인할 수 있습니다. true = 최초 매니저, false = 최초 매니저 아님"
+    )
+    public ResponseEntity isInitialManager() {
+        boolean result = userService.isInitialManagerValid();
+        return ResponseEntity.ok(ApiResponse.of(200, "최초 매니저 여부 확인 성공", result));
+    }
+
+
 }

--- a/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
@@ -27,7 +27,9 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -531,6 +533,39 @@ public class UserController {
         boolean result = userService.isInitialManagerValid();
         return ResponseEntity.ok(ApiResponse.of(200, "최초 매니저 여부 확인 성공", result));
     }
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "회원 이름으로 검색",
+            description = "특정 관리 페이지 내에서 이름을 포함한 회원을 검색합니다."
+    )
+    public ResponseEntity<ApiResponse<?>> searchMembersByName(
+            @RequestParam String username,
+            @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<?> result = userService.searchMembersByName( username, pageable);
+        return ResponseEntity.ok(ApiResponse.of(200, "회원 검색 성공", result));
+    }
+
+
+    @GetMapping("/search/manager")
+    @Operation(
+            summary = "매니저 이름으로 검색",
+            description = "특정 관리 페이지 내에서 이름을 포함한 매니저를 검색합니다."
+    )
+    public ResponseEntity<ApiResponse<?>> searchManagersByName(
+            @RequestParam String username,
+            @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<?> result = userService.searchManagerByName( username, pageable);
+        return ResponseEntity.ok(ApiResponse.of(200, "매니저 검색 성공", result));
+    }
+
+
 
 
 }

--- a/backend/src/main/java/com/example/backend/domain/user/dto/response/ApproveUserListForInitialManagerResponseDto.java
+++ b/backend/src/main/java/com/example/backend/domain/user/dto/response/ApproveUserListForInitialManagerResponseDto.java
@@ -27,15 +27,23 @@ public class ApproveUserListForInitialManagerResponseDto {
 
     ApprovalStatus approvalStatus;
 
+    String departmentName;
+
 
 
     public ApproveUserListForInitialManagerResponseDto(User user){
-        this.userId=user.getId();
+        this.userId = user.getId();
         this.name = user.getName();
         this.email = user.getEmail();
         this.phoneNumber = user.getPhoneNumber();
         this.requestDate = user.getCreatedAt();
-        this.approvalStatus=user.getApprovalStatus();
+        this.approvalStatus = user.getApprovalStatus();
+
+        if (user.getDepartment() == null || user.getDepartment().getName() == null) {
+            this.departmentName = "매니저";
+        } else {
+            this.departmentName = user.getDepartment().getName();
+        }
     }
 
 }

--- a/backend/src/main/java/com/example/backend/domain/user/dto/response/ApproveUserListForInitialManagerResponseDto.java
+++ b/backend/src/main/java/com/example/backend/domain/user/dto/response/ApproveUserListForInitialManagerResponseDto.java
@@ -2,6 +2,8 @@ package com.example.backend.domain.user.dto.response;
 
 
 import com.example.backend.domain.user.entity.User;
+import com.example.backend.enums.ApprovalStatus;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,11 +23,19 @@ public class ApproveUserListForInitialManagerResponseDto {
 
     String phoneNumber;
 
+    LocalDateTime requestDate;
+
+    ApprovalStatus approvalStatus;
+
+
+
     public ApproveUserListForInitialManagerResponseDto(User user){
         this.userId=user.getId();
         this.name = user.getName();
         this.email = user.getEmail();
         this.phoneNumber = user.getPhoneNumber();
+        this.requestDate = user.getCreatedAt();
+        this.approvalStatus=user.getApprovalStatus();
     }
 
 }

--- a/backend/src/main/java/com/example/backend/domain/user/dto/response/ApproveUserListForManagerResponseDto.java
+++ b/backend/src/main/java/com/example/backend/domain/user/dto/response/ApproveUserListForManagerResponseDto.java
@@ -27,13 +27,21 @@ public class ApproveUserListForManagerResponseDto {
 
     ApprovalStatus approvalStatus;
 
+    String departmentName;
+
     public ApproveUserListForManagerResponseDto(User user) {
         this.userId = user.getId();
         this.name = user.getName();
         this.email = user.getEmail();
-        this.phoneNumber = maskPhoneNumber(user.getPhoneNumber());
+        this.phoneNumber = user.getPhoneNumber();
         this.requestDate = user.getCreatedAt();
-        this.approvalStatus=user.getApprovalStatus();
+        this.approvalStatus = user.getApprovalStatus();
+
+        if (user.getDepartment() == null || user.getDepartment().getName() == null) {
+            this.departmentName = "매니저";
+        } else {
+            this.departmentName = user.getDepartment().getName();
+        }
     }
 
     private String maskPhoneNumber(String phoneNumber) {

--- a/backend/src/main/java/com/example/backend/domain/user/dto/response/ApproveUserListForManagerResponseDto.java
+++ b/backend/src/main/java/com/example/backend/domain/user/dto/response/ApproveUserListForManagerResponseDto.java
@@ -2,6 +2,8 @@ package com.example.backend.domain.user.dto.response;
 
 
 import com.example.backend.domain.user.entity.User;
+import com.example.backend.enums.ApprovalStatus;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,13 +21,19 @@ public class ApproveUserListForManagerResponseDto {
 
     String email;
 
-    String maskedPhoneNumber;
+    String phoneNumber;
+
+    LocalDateTime requestDate;
+
+    ApprovalStatus approvalStatus;
 
     public ApproveUserListForManagerResponseDto(User user) {
         this.userId = user.getId();
         this.name = user.getName();
         this.email = user.getEmail();
-        this.maskedPhoneNumber = maskPhoneNumber(user.getPhoneNumber());
+        this.phoneNumber = maskPhoneNumber(user.getPhoneNumber());
+        this.requestDate = user.getCreatedAt();
+        this.approvalStatus=user.getApprovalStatus();
     }
 
     private String maskPhoneNumber(String phoneNumber) {

--- a/backend/src/main/java/com/example/backend/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/user/repository/UserRepository.java
@@ -104,5 +104,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
             Long excludeUserId
     );
 
+    // 사용자(회원) 이름 포함 검색
+    Page<User> findByNameContainingAndManagementDashboardAndRole(
+            String name,
+            ManagementDashboard managementDashboard,
+            Role role,
+            Pageable pageable
+    );
+
+
+
 
 }

--- a/backend/src/main/java/com/example/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/domain/user/service/UserService.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -682,6 +683,7 @@ public class UserService {
         }
     }
 
+
     public List<User> findByManagerList(ManagementDashboard managementDashboard){
 
         Role role = roleService.findRoleByRoleType(RoleType.MANAGER);
@@ -746,5 +748,58 @@ public class UserService {
         // 실제 검색 실행 (승인된 사용자만 조회)
         return userRepository.searchBasicUsers(managementDashboardId, searchKeyword, RoleType.USER, ApprovalStatus.APPROVED, pageable);
     }
+
+
+
+    public Page<?> searchMembersByName(String username, Pageable pageable) {
+        Role role = roleService.findRoleByRoleType(RoleType.USER);
+        User user = findById(tokenService.getIdFromToken());
+        validManager();
+
+        // 2. 관리 페이지 엔티티 조회
+        ManagementDashboard dashboard = managementDashboardRepository.findById(user.getManagementDashboard().getId())
+                .orElseThrow(()-> new BusinessLogicException(ExceptionCode.MANAGEMENT_DASHBOARD_NOT_FOUND));
+
+        // 3. 해당 관리 페이지 소속인지 확인
+        validateManagementDashboardUser(dashboard);
+        Page<User> users = userRepository.findByNameContainingAndManagementDashboardAndRole(
+                username,
+                dashboard,
+                role,
+                pageable
+        );
+
+        if (validInitialManager(dashboard)) {
+            return users.map(ApproveUserListForInitialManagerResponseDto::new);
+        } else {
+            return users.map(ApproveUserListForManagerResponseDto::new);
+        }
+    }
+
+    public Page<?> searchManagerByName(String username, Pageable pageable) {
+        Role role = roleService.findRoleByRoleType(RoleType.MANAGER);
+        User user = findById(tokenService.getIdFromToken());
+
+        ManagementDashboard dashboard = managementDashboardRepository.findById(user.getManagementDashboard().getId())
+                .orElseThrow(()-> new BusinessLogicException(ExceptionCode.MANAGEMENT_DASHBOARD_NOT_FOUND));
+
+        isInitialManagerValid();
+        Page<User> users = userRepository.findByNameContainingAndManagementDashboardAndRole(
+                username,
+                dashboard,
+                role,
+                pageable
+        );
+
+        if (validInitialManager(dashboard)) {
+            return users.map(ApproveUserListForInitialManagerResponseDto::new);
+        } else {
+            return users.map(ApproveUserListForManagerResponseDto::new);
+        }
+    }
+
+
+
+
 
 }

--- a/backend/src/main/java/com/example/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/domain/user/service/UserService.java
@@ -319,6 +319,22 @@ public class UserService {
         userRepository.save(requestUser);
     }
 
+    public boolean isInitialManagerValid(){
+        User user = findById(tokenService.getIdFromToken());
+
+        // 1. 매니저 권한인지 확인
+        validManager();
+
+        // 2. 관리 페이지 엔티티 조회
+        ManagementDashboard dashboard = managementDashboardRepository.findById(user.getManagementDashboard().getId())
+                .orElseThrow(()-> new BusinessLogicException(ExceptionCode.MANAGEMENT_DASHBOARD_NOT_FOUND));
+
+        // 3. 해당 관리 페이지 소속인지 확인
+        validateManagementDashboardUser(dashboard);
+
+        // 4. 최초 매니저 여부 확인
+        return validInitialManager(dashboard);
+    }
     // 매니저 승인 처리
     @Transactional
     public void approveManager(Long userId) {

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -50,7 +50,9 @@ public class SecurityConfigJuseyo {
                         .requestMatchers( "/api/v1/users/chat/list/**","/api/v1/users/chat/**").hasAnyRole("MANAGER", "USER","ADMIN")
                         //회원
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/signup/**","/api/v1/users/login","/api/v1/users/emails/findPassword","/api/v1/users/emails/**","/api/v1/users/duplication/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/users/approve","/api/v1/users/request","/api/v1/users/approve/**","/api/v1/users/reject/**")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/approve","/api/v1/users/request",
+                                "/api/v1/users/approve/**","/api/v1/users/reject/**"
+                        ,"/api/v1/users/validation/initialManager/**")
                         .hasAnyAuthority("ROLE_MANAGER", "ROLE_ADMIN")
                         //비품
                         .requestMatchers(HttpMethod.PUT, "/api/v1/items/**").hasRole("MANAGER") // 비품수정은 매니저만 가능

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -52,7 +52,8 @@ public class SecurityConfigJuseyo {
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/signup/**","/api/v1/users/login","/api/v1/users/emails/findPassword","/api/v1/users/emails/**","/api/v1/users/duplication/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/approve","/api/v1/users/request",
                                 "/api/v1/users/approve/**","/api/v1/users/reject/**"
-                        ,"/api/v1/users/validation/initialManager/**")
+                        ,"/api/v1/users/validation/initialManager/**",
+                                "/api/v1/users/search/**")
                         .hasAnyAuthority("ROLE_MANAGER", "ROLE_ADMIN")
                         //비품
                         .requestMatchers(HttpMethod.PUT, "/api/v1/items/**").hasRole("MANAGER") // 비품수정은 매니저만 가능

--- a/frontend/src/app/settings/approve/page.tsx
+++ b/frontend/src/app/settings/approve/page.tsx
@@ -126,6 +126,10 @@ export default function ApprovePage() {
               핸드폰 번호
             </th>
             <th className="border border-gray-200 px-4 py-2 text-left">
+              부서 이름
+            </th>
+            {/* 부서 이름 추가 */}
+            <th className="border border-gray-200 px-4 py-2 text-left">
               요청일
             </th>
             <th className="border border-gray-200 px-4 py-2 text-left">상태</th>
@@ -141,6 +145,10 @@ export default function ApprovePage() {
               <td className="border border-gray-200 px-4 py-2">
                 {user.phoneNumber}
               </td>
+              <td className="border border-gray-200 px-4 py-2">
+                {user.departmentName || "N/A"}
+              </td>{" "}
+              {/* 부서 이름 추가 */}
               <td className="border border-gray-200 px-4 py-2">
                 {new Date(user.requestDate).toLocaleString("ko-KR", {
                   year: "numeric",

--- a/frontend/src/app/settings/approve/page.tsx
+++ b/frontend/src/app/settings/approve/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ApprovePage() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // 샘플 데이터
+  const users: {
+    pageName: string;
+    email: string;
+    name: string;
+    phone: string;
+    requestDate: string;
+    status: keyof typeof statusStyles;
+  }[] = [
+    {
+      pageName: "카페 주세요",
+      email: "kim@example.com",
+      name: "김주세요",
+      phone: "010-1234-5678",
+      requestDate: "2023-08-15",
+      status: "대기중",
+    },
+    {
+      pageName: "레스토랑 주세요",
+      email: "park@example.com",
+      name: "박맛있는",
+      phone: "010-9876-5432",
+      requestDate: "2023-08-14",
+      status: "대기중",
+    },
+    {
+      pageName: "미용실 주세요",
+      email: "lee@example.com",
+      name: "이발사",
+      phone: "010-5555-7777",
+      requestDate: "2023-08-12",
+      status: "승인됨",
+    },
+    {
+      pageName: "꽃집 주세요",
+      email: "choi@example.com",
+      name: "최꽃집",
+      phone: "010-3333-4444",
+      requestDate: "2023-08-10",
+      status: "거절됨",
+    },
+    {
+      pageName: "서점 주세요",
+      email: "jung@example.com",
+      name: "정책방",
+      phone: "010-2222-8888",
+      requestDate: "2023-08-09",
+      status: "대기중",
+    },
+  ];
+
+  // 상태별 스타일
+  const statusStyles = {
+    대기중: "bg-yellow-100 text-yellow-600",
+    승인됨: "bg-green-100 text-green-600",
+    거절됨: "bg-red-100 text-red-600",
+  };
+
+  const handleApprove = (email: string) => {
+    alert(`${email} 승인되었습니다.`);
+  };
+
+  const handleReject = (email: string) => {
+    alert(`${email} 거절되었습니다.`);
+  };
+
+  return (
+    <div className="p-6 bg-white">
+      <h1 className="text-2xl font-bold text-[#0047AB] mb-6">
+        승인 대기 요청 승인
+      </h1>
+
+      {/* 검색 필드 */}
+      <div className="mb-4 flex items-center">
+        <input
+          type="text"
+          placeholder="이름, 이메일, 페이지명으로 검색..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="flex-grow px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-[#0047AB]"
+        />
+        <button className="ml-2 px-4 py-2 bg-[#0047AB] text-white rounded-lg hover:bg-blue-800">
+          검색
+        </button>
+      </div>
+
+      {/* 테이블 */}
+      <table className="w-full border-collapse border border-gray-200">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border border-gray-200 px-4 py-2 text-left">
+              페이지 이름
+            </th>
+            <th className="border border-gray-200 px-4 py-2 text-left">
+              요청자 이메일
+            </th>
+            <th className="border border-gray-200 px-4 py-2 text-left">
+              요청자 이름
+            </th>
+            <th className="border border-gray-200 px-4 py-2 text-left">
+              핸드폰 번호
+            </th>
+            <th className="border border-gray-200 px-4 py-2 text-left">
+              요청일
+            </th>
+            <th className="border border-gray-200 px-4 py-2 text-left">상태</th>
+            <th className="border border-gray-200 px-4 py-2 text-left">액션</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user, index) => (
+            <tr key={index} className="hover:bg-gray-50">
+              <td className="border border-gray-200 px-4 py-2">
+                {user.pageName}
+              </td>
+              <td className="border border-gray-200 px-4 py-2">{user.email}</td>
+              <td className="border border-gray-200 px-4 py-2">{user.name}</td>
+              <td className="border border-gray-200 px-4 py-2">{user.phone}</td>
+              <td className="border border-gray-200 px-4 py-2">
+                {user.requestDate}
+              </td>
+              <td
+                className={`border border-gray-200 px-4 py-2 rounded-lg text-center ${
+                  statusStyles[user.status as keyof typeof statusStyles]
+                }`}
+              >
+                {user.status}
+              </td>
+              <td className="border border-gray-200 px-4 py-2 flex space-x-2">
+                {user.status === "대기중" && (
+                  <>
+                    <button
+                      onClick={() => handleApprove(user.email)}
+                      className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600"
+                    >
+                      승인
+                    </button>
+                    <button
+                      onClick={() => handleReject(user.email)}
+                      className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
+                    >
+                      거절
+                    </button>
+                  </>
+                )}
+                {user.status === "승인됨" && (
+                  <span className="px-4 py-2 bg-blue-500 text-white rounded-lg">
+                    승인됨
+                  </span>
+                )}
+                {user.status === "거절됨" && (
+                  <span className="px-4 py-2 bg-red-500 text-white rounded-lg">
+                    거절됨
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* 페이지네이션 */}
+      <div className="flex justify-center items-center mt-4 space-x-2">
+        <button className="px-3 py-1 bg-gray-200 rounded-lg hover:bg-gray-300">
+          이전
+        </button>
+        <button className="px-3 py-1 bg-blue-500 text-white rounded-lg">
+          1
+        </button>
+        <button className="px-3 py-1 bg-gray-200 rounded-lg hover:bg-gray-300">
+          2
+        </button>
+        <button className="px-3 py-1 bg-gray-200 rounded-lg hover:bg-gray-300">
+          3
+        </button>
+        <button className="px-3 py-1 bg-gray-200 rounded-lg hover:bg-gray-300">
+          다음
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/settings/approve/page.tsx
+++ b/frontend/src/app/settings/approve/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { fetchUsersByStatus } from "@/utils/statusUserList"; // 유저 상태별 데이터 가져오기 함수
-import { useGlobalLoginUser } from "@/stores/auth/loginMember"; // 로그인 유저 정보 가져오기
+import { fetchUsersByStatus } from "@/utils/statusUserList";
+import { useGlobalLoginUser } from "@/stores/auth/loginMember";
 
 export default function ApprovePage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
-  const { loginUser } = useGlobalLoginUser(); // 로그인 유저 정보
-  const managementDashboardName = loginUser.managementDashboardName; // 관리 페이지 이름 가져오기
+  const { loginUser } = useGlobalLoginUser();
+  const managementDashboardName = loginUser.managementDashboardName;
   const [isInitialManager, setIsInitialManager] = useState(false);
   const [selectedRole, setSelectedRole] = useState<"회원" | "매니저">("회원");
   const [users, setUsers] = useState([]);
@@ -17,14 +17,13 @@ export default function ApprovePage() {
   >("approve");
 
   useEffect(() => {
-    // 최초 매니저 여부 확인 (예시: /validation/initialManager API 호출)
     const checkInitialManager = async () => {
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/users/validation/initialManager`,
-        { credentials: "include" } // 쿠키 포함
+        { credentials: "include" }
       );
-      const data = await response.json();
-      setIsInitialManager(data.isInitialManager);
+      const result = await response.json();
+      setIsInitialManager(result.data);
     };
 
     checkInitialManager();
@@ -37,14 +36,10 @@ export default function ApprovePage() {
     }
 
     const fetchUsers = async () => {
-      if (!managementDashboardName) {
-        console.error("관리 페이지 이름이 없습니다.");
-        return;
-      }
-
       try {
         const usersData = await fetchUsersByStatus(
           filterStatus,
+          selectedRole, // 역할에 따라 API 호출
           managementDashboardName,
           currentPage,
           10
@@ -56,7 +51,7 @@ export default function ApprovePage() {
     };
 
     fetchUsers();
-  }, [filterStatus, managementDashboardName, currentPage]);
+  }, [filterStatus, selectedRole, managementDashboardName, currentPage]);
 
   const handleApprove = (email: string) => {
     alert(`${email} 승인되었습니다.`);
@@ -69,7 +64,7 @@ export default function ApprovePage() {
   return (
     <div className="p-6 bg-white">
       <h1 className="text-2xl font-bold text-[#0047AB] mb-6">
-        승인 대기 요청 승인
+        {selectedRole === "회원" ? "사용자 관리" : "매니저 관리"}
       </h1>
 
       {isInitialManager && (
@@ -147,7 +142,6 @@ export default function ApprovePage() {
                 {user.phoneNumber}
               </td>
               <td className="border border-gray-200 px-4 py-2">
-                {/* 요청일을 날짜와 시간만 표시 */}
                 {new Date(user.requestDate).toLocaleString("ko-KR", {
                   year: "numeric",
                   month: "2-digit",

--- a/frontend/src/components/Navigation/Navigation.tsx
+++ b/frontend/src/components/Navigation/Navigation.tsx
@@ -265,7 +265,7 @@ export default function Navigation({
           </li>
           <li className="menu-item">
             <Link
-              href="/settings/users"
+              href="/settings/approve"
               className={`menu-link ${
                 activeMenu === "user-management" ? "active" : ""
               }`}
@@ -342,7 +342,11 @@ export default function Navigation({
   );
 
   return (
-    <aside className={`juseyo-sidebar ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}`}>
+    <aside
+      className={`juseyo-sidebar ${
+        isSidebarCollapsed ? "sidebar-collapsed" : ""
+      }`}
+    >
       <div className="juseyo-menu-container">
         {/* 사이드바 접기/펼치기 버튼 */}
         {onToggleSidebar && (

--- a/frontend/src/utils/statusUserList.ts
+++ b/frontend/src/utils/statusUserList.ts
@@ -1,0 +1,54 @@
+export const fetchUsersByStatus = async (
+  status: "approve" | "reject" | "request",
+  managementDashboardName: string,
+  page: number = 1,
+  size: number = 10
+) => {
+  const endpoints = {
+    approve: "/api/v1/users/approve",
+    reject: "/api/v1/users/reject",
+    request: "/api/v1/users/request",
+  };
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  const url = `${baseUrl}${
+    endpoints[status]
+  }?managementDashboardName=${encodeURIComponent(
+    managementDashboardName
+  )}&page=${page}&size=${size}`;
+
+  const response = await fetch(url, {
+    credentials: "include", // 쿠키 포함
+  });
+
+  if (!response.ok) {
+    console.error("응답 실패:", response.status);
+    throw new Error("데이터를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const data = await response.json();
+  console.log("받은 API 응답:", data); // 어떤 데이터가 오는지 확인해봐!
+
+  // ✨ 여기서 data.data에 바로 접근하도록 수정! ✨
+  if (
+    !data ||
+    !data.data || // data.data는 Page 객체야!
+    !data.data.content // Page 객체 안에 content가 있어!
+  ) {
+    console.error("API 응답 형식이 올바르지 않습니다:", data);
+    throw new Error("API 응답 형식이 올바르지 않습니다.");
+  }
+
+  // ✨ 반환할 때도 data.data에 바로 접근해서 필요한 정보 가져오기! ✨
+  const pageData = data.data; // Page 객체를 따로 변수에 담으면 보기 편해!
+
+  return {
+    users: pageData.content, // 유저 리스트는 Page 객체의 content 필드에 있어
+    pageable: pageData.pageable, // 페이지 정보
+    totalElements: pageData.totalElements, // 전체 요소 수
+    totalPages: pageData.totalPages, // 전체 페이지 수
+    currentPage: pageData.number + 1, // 현재 페이지 (0부터 시작하므로 +1)
+    size: pageData.size, // 페이지 크기
+  };
+};

--- a/frontend/src/utils/statusUserList.ts
+++ b/frontend/src/utils/statusUserList.ts
@@ -1,19 +1,27 @@
 export const fetchUsersByStatus = async (
   status: "approve" | "reject" | "request",
+  role: "회원" | "매니저", // 역할 추가
   managementDashboardName: string,
   page: number = 1,
   size: number = 10
 ) => {
   const endpoints = {
-    approve: "/api/v1/users/approve",
-    reject: "/api/v1/users/reject",
-    request: "/api/v1/users/request",
+    회원: {
+      approve: "/api/v1/users/approve",
+      reject: "/api/v1/users/reject",
+      request: "/api/v1/users/request",
+    },
+    매니저: {
+      approve: "/api/v1/users/approve/manager",
+      reject: "/api/v1/users/reject/manager",
+      request: "/api/v1/users/request/manager",
+    },
   };
 
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
 
   const url = `${baseUrl}${
-    endpoints[status]
+    endpoints[role][status]
   }?managementDashboardName=${encodeURIComponent(
     managementDashboardName
   )}&page=${page}&size=${size}`;
@@ -28,7 +36,6 @@ export const fetchUsersByStatus = async (
   }
 
   const data = await response.json();
-  console.log("받은 API 응답:", data); // 어떤 데이터가 오는지 확인해봐!
 
   // ✨ 여기서 data.data에 바로 접근하도록 수정! ✨
   if (


### PR DESCRIPTION
## 📒 개요

회원 승인, 거부, 요청 조회 페이지 구현

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#241 
> closed #Issue_number

<br>

## 🛠️ 작업사항

- 최초 매니저 여부 확인
최초 매니저 여부를 확인하는 API 호출 및 상태 관리.

- 회원 및 매니저 관리
회원과 매니저를 선택하여 각각의 승인, 요청, 거부 리스트를 조회할 수 있는 기능 구현.
부서 이름 표시

UI 개선
역할(회원/매니저) 선택 드롭다운 추가.

<br>

## 📸 스크린샷(선택)
<img width="1208" alt="스크린샷 2025-05-26 오전 2 13 18" src="https://github.com/user-attachments/assets/32c44022-e416-4fbe-902c-fdae86d8e7c9" />
<img width="1208" alt="스크린샷 2025-05-26 오전 2 13 29" src="https://github.com/user-attachments/assets/9ecd23e9-bcc6-489a-83c2-b0c331b682c0" />


