### PR TITLE
[ front / feat ] 248 : 회원 마이페이지 기능, 정보 수정 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/domain/user/service/UserService.java
@@ -386,6 +386,7 @@ public class UserService {
         return userRepository.save(user);
     }
 
+    @Transactional
     public User updatePassword(UserPatchRequestDto.changePassword changePasswordDto){
         User user = findById(tokenService.getIdFromToken());
 
@@ -394,6 +395,7 @@ public class UserService {
 
         user.setPassword(passwordEncoder.encode(changePasswordDto.getChangePassword()));
         user.setModifiedAt(LocalDateTime.now());
+
         return userRepository.save(user);
     }
 

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -49,6 +49,7 @@ public class SecurityConfigJuseyo {
                         //채팅
                         .requestMatchers( "/api/v1/users/chat/list/**","/api/v1/users/chat/**").hasAnyRole("MANAGER", "USER","ADMIN")
                         //회원
+                        .requestMatchers(HttpMethod.PATCH,"/api/v1/users/name","/api/v1/users/email","/api/v1/users/password","/api/v1/users/phoneNumber").hasAnyRole("MANAGER", "USER","ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/signup/**","/api/v1/users/login","/api/v1/users/emails/findPassword","/api/v1/users/emails/**","/api/v1/users/duplication/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/approve","/api/v1/users/request","/api/v1/users/approve/**","/api/v1/users/reject/**")
                         .hasAnyAuthority("ROLE_MANAGER", "ROLE_ADMIN")

--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -31,9 +31,31 @@ export function Header({ onToggleSidebar }: HeaderProps) {
         <div className="flex items-center">
           {isLogin ? (
             <>
+              <Link
+                href="/user"
+                className="flex items-center space-x-2 px-3 py-2 rounded-full bg-gray-100 hover:bg-gray-200 transition text-gray-800 text-sm font-medium shadow-sm"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="w-5 h-5 text-gray-600"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25a8.25 8.25 0 0115 0"
+                  />
+                </svg>
+                <span>{loginUser?.name || "유저"}</span>
+              </Link>
+
               <div className="mr-4">
                 <NotificationBell />
               </div>
+
               <button
                 onClick={logoutAndHome}
                 className="bg-white border border-blue-500 text-blue-500 px-4 py-1.5 rounded-md text-sm hover:bg-blue-50"

--- a/frontend/src/app/user/page.tsx
+++ b/frontend/src/app/user/page.tsx
@@ -2,6 +2,12 @@
 
 import { useState } from "react";
 import { useGlobalLoginUser } from "@/stores/auth/loginMember";
+import {
+  updateUserName,
+  updateUserEmail,
+  updateUserPhoneNumber,
+  updateUserPassword,
+} from "@/utils/modifyUser";
 
 const UserProfilePage = () => {
   const { loginUser } = useGlobalLoginUser(); // 현재 로그인한 유저 정보
@@ -25,36 +31,8 @@ const UserProfilePage = () => {
   const [currentPassword, setCurrentPassword] = useState("");
 
   const handleSaveName = async () => {
-    const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-    // 유효성 검사
-    if (!userInfo.name.trim()) {
-      alert("이름을 입력해주세요.");
-      return;
-    }
-    if (userInfo.name.length > 20) {
-      alert("이름은 최대 20자까지 가능합니다.");
-      return;
-    }
-    const nameRegex = /^[가-힣]+$/;
-    if (!nameRegex.test(userInfo.name)) {
-      alert("이름은 한글만 입력 가능합니다.");
-      return;
-    }
-
     try {
-      const response = await fetch(`${API_BASE}/api/v1/users/name`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-        body: JSON.stringify({ name: userInfo.name }),
-      });
-
-      if (!response.ok) throw new Error("이름을 수정할 수 없습니다.");
-
-      const data = await response.json();
+      const data = await updateUserName(userInfo.name);
       alert("이름이 성공적으로 수정되었습니다.");
       setUserInfo((prev) => ({ ...prev, name: data.data.name }));
       setIsEditing((prev) => ({ ...prev, name: false }));
@@ -64,32 +42,8 @@ const UserProfilePage = () => {
   };
 
   const handleSaveEmail = async () => {
-    const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-    // 유효성 검사
-    if (!userInfo.email.trim()) {
-      alert("이메일을 입력해주세요.");
-      return;
-    }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(userInfo.email)) {
-      alert("유효한 이메일 형식이 아닙니다.");
-      return;
-    }
-
     try {
-      const response = await fetch(`${API_BASE}/api/v1/users/email`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-        body: JSON.stringify({ email: userInfo.email }),
-      });
-
-      if (!response.ok) throw new Error("이메일을 수정할 수 없습니다.");
-
-      const data = await response.json();
+      const data = await updateUserEmail(userInfo.email);
       alert("이메일이 성공적으로 수정되었습니다.");
       setUserInfo((prev) => ({ ...prev, email: data.data.email }));
       setIsEditing((prev) => ({ ...prev, email: false }));
@@ -99,32 +53,8 @@ const UserProfilePage = () => {
   };
 
   const handleSavePhoneNumber = async () => {
-    const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-    // 유효성 검사
-    if (!userInfo.phoneNumber.trim()) {
-      alert("핸드폰 번호를 입력해주세요.");
-      return;
-    }
-    const phoneRegex = /^010-\d{4}-\d{4}$/;
-    if (!phoneRegex.test(userInfo.phoneNumber)) {
-      alert("전화번호 형식은 010-1234-5678이어야 합니다.");
-      return;
-    }
-
     try {
-      const response = await fetch(`${API_BASE}/api/v1/users/phoneNumber`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-        body: JSON.stringify({ phoneNumber: userInfo.phoneNumber }),
-      });
-
-      if (!response.ok) throw new Error("핸드폰 번호를 수정할 수 없습니다.");
-
-      const data = await response.json();
+      const data = await updateUserPhoneNumber(userInfo.phoneNumber);
       alert("핸드폰 번호가 성공적으로 수정되었습니다.");
       setUserInfo((prev) => ({ ...prev, phoneNumber: data.data.phoneNumber }));
       setIsEditing((prev) => ({ ...prev, phoneNumber: false }));
@@ -134,51 +64,8 @@ const UserProfilePage = () => {
   };
 
   const handlePasswordChange = async () => {
-    const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-    // 유효성 검사
-    if (
-      !newPassword.trim() ||
-      !confirmPassword.trim() ||
-      !currentPassword.trim()
-    ) {
-      alert("모든 필드를 입력해주세요.");
-      return;
-    }
-
-    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*\W).{8,20}$/;
-    if (!passwordRegex.test(newPassword)) {
-      alert("비밀번호는 영문자, 숫자, 특수문자를 포함한 8~20자리여야 합니다.");
-      return;
-    }
-
-    if (newPassword !== confirmPassword) {
-      alert("새 비밀번호가 일치하지 않습니다.");
-      return;
-    }
-
     try {
-      const response = await fetch(`${API_BASE}/api/v1/users/password`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-        body: JSON.stringify({
-          beforePassword: currentPassword,
-          changePassword: newPassword,
-        }),
-      });
-
-      if (!response.ok) {
-        if (response.status === 400) {
-          alert("이전 비밀번호가 틀립니다.");
-        } else {
-          throw new Error("비밀번호를 변경할 수 없습니다.");
-        }
-        return;
-      }
-
+      const data = await updateUserPassword(currentPassword, newPassword);
       alert("비밀번호가 성공적으로 변경되었습니다.");
       setNewPassword("");
       setConfirmPassword("");
@@ -190,208 +77,225 @@ const UserProfilePage = () => {
 
   return (
     <div className="max-w-4xl mx-auto p-8 bg-white shadow-lg rounded-lg mt-12">
-      <h1 className="text-4xl font-bold text-center mb-12 text-gray-800">
-        회원 정보 관리
+      <h1 className="text-3xl font-bold text-center mb-8 text-gray-800">
+        사용자 정보
       </h1>
 
-      {/* 관리 페이지 이름 */}
-      <div className="mb-6">
-        <label className="block text-sm font-medium text-gray-700">
-          관리 페이지 이름
-        </label>
-        <input
-          type="text"
-          value={userInfo.managementPageName}
-          disabled
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-gray-100 text-gray-600 cursor-not-allowed"
-        />
-      </div>
-
-      {/* 부서 이름 */}
-      <div className="mb-6">
-        <label className="block text-sm font-medium text-gray-700">
-          부서 이름
-        </label>
-        <input
-          type="text"
-          value={userInfo.departmentName}
-          disabled
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-gray-100 text-gray-600 cursor-not-allowed"
-        />
-      </div>
-
-      {/* 이름 */}
-      <div className="mb-6">
-        <label className="block text-sm font-medium text-gray-700">이름</label>
-        {isEditing.name ? (
-          <div className="flex gap-4">
-            <input
-              type="text"
-              value={userInfo.name}
-              onChange={(e) =>
-                setUserInfo((prev) => ({ ...prev, name: e.target.value }))
-              }
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg"
-            />
-            <button
-              onClick={handleSaveName}
-              className="px-4 py-2 bg-blue-500 text-white rounded-lg"
-            >
-              저장
-            </button>
-            <button
-              onClick={() => {
-                setUserInfo((prev) => ({ ...prev, name: loginUser.name })); // 초기 값으로 복원
-                setIsEditing((prev) => ({ ...prev, name: false })); // 수정 모드 종료
-              }}
-              className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
-            >
-              취소
-            </button>
-          </div>
-        ) : (
-          <div className="flex justify-between items-center">
-            <span>{userInfo.name}</span>
-            <button
-              onClick={() => setIsEditing((prev) => ({ ...prev, name: true }))}
-              className="text-blue-500"
-            >
-              수정
-            </button>
-          </div>
-        )}
-      </div>
-
-      {/* 이메일 */}
-      <div className="mb-6">
-        <label className="block text-sm font-medium text-gray-700">
-          이메일
-        </label>
-        {isEditing.email ? (
-          <div className="flex gap-4">
-            <input
-              type="email"
-              value={userInfo.email}
-              onChange={(e) =>
-                setUserInfo((prev) => ({ ...prev, email: e.target.value }))
-              }
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg"
-            />
-            <button
-              onClick={handleSaveEmail}
-              className="px-4 py-2 bg-blue-500 text-white rounded-lg"
-            >
-              저장
-            </button>
-            <button
-              onClick={() => {
-                setUserInfo((prev) => ({ ...prev, email: loginUser.email })); // 초기 값으로 복원
-                setIsEditing((prev) => ({ ...prev, email: false })); // 수정 모드 종료
-              }}
-              className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
-            >
-              취소
-            </button>
-          </div>
-        ) : (
-          <div className="flex justify-between items-center">
-            <span>{userInfo.email}</span>
-            <button
-              onClick={() => setIsEditing((prev) => ({ ...prev, email: true }))}
-              className="text-blue-500"
-            >
-              수정
-            </button>
-          </div>
-        )}
-      </div>
-
-      {/* 핸드폰 번호 */}
-      <div className="mb-6">
-        <label className="block text-sm font-medium text-gray-700">
-          핸드폰 번호
-        </label>
-        {isEditing.phoneNumber ? (
-          <div className="flex gap-4">
-            <input
-              type="text"
-              value={userInfo.phoneNumber}
-              onChange={(e) =>
-                setUserInfo((prev) => ({
-                  ...prev,
-                  phoneNumber: e.target.value,
-                }))
-              }
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg"
-              placeholder="010-1234-5678"
-            />
-            <button
-              onClick={handleSavePhoneNumber}
-              className="px-4 py-2 bg-blue-500 text-white rounded-lg"
-            >
-              저장
-            </button>
-            <button
-              onClick={() => {
-                setUserInfo((prev) => ({
-                  ...prev,
-                  phoneNumber: loginUser.phoneNumber,
-                })); // 초기 값으로 복원
-                setIsEditing((prev) => ({ ...prev, phoneNumber: false })); // 수정 모드 종료
-              }}
-              className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
-            >
-              취소
-            </button>
-          </div>
-        ) : (
-          <div className="flex justify-between items-center">
-            <span>{userInfo.phoneNumber}</span>
-            <button
-              onClick={() =>
-                setIsEditing((prev) => ({ ...prev, phoneNumber: true }))
-              }
-              className="text-blue-500"
-            >
-              수정
-            </button>
-          </div>
-        )}
-      </div>
-
-      {/* 비밀번호 변경 */}
-      <div className="mb-6">
-        <label className="block text-sm font-medium text-gray-700">
-          비밀번호 변경
-        </label>
-        <div className="flex flex-col gap-4">
-          <input
-            type="password"
-            value={currentPassword}
-            onChange={(e) => setCurrentPassword(e.target.value)}
-            placeholder="현재 비밀번호"
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg"
-          />
-          <input
-            type="password"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            placeholder="새 비밀번호"
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg"
-          />
-          <input
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            placeholder="새 비밀번호 확인"
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg"
-          />
-          <button
-            onClick={handlePasswordChange}
-            className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+      <div className="flex flex-col items-center mb-8">
+        <div className="w-24 h-24 bg-blue-100 rounded-full flex items-center justify-center mb-4">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-12 h-12 text-blue-500"
           >
-            변경
-          </button>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25a8.25 8.25 0 0115 0"
+            />
+          </svg>
+        </div>
+        <h2 className="text-xl font-semibold text-gray-800">{userInfo.name}</h2>
+        <p className="text-gray-500">{userInfo.email}</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* 관리 페이지 이름 */}
+        <div className="p-4 bg-gray-50 rounded-lg shadow-sm">
+          <h3 className="text-sm font-medium text-gray-500">관리 페이지</h3>
+          <p className="text-lg font-semibold text-gray-800 mt-1">
+            {userInfo.managementPageName}
+          </p>
+        </div>
+
+        {/* 부서 이름 */}
+        <div className="p-4 bg-gray-50 rounded-lg shadow-sm">
+          <h3 className="text-sm font-medium text-gray-500">부서</h3>
+          <p className="text-lg font-semibold text-gray-800 mt-1">
+            {userInfo.departmentName}
+          </p>
+        </div>
+
+        {/* 이름 */}
+        <div className="p-4 bg-gray-50 rounded-lg shadow-sm">
+          <h3 className="text-sm font-medium text-gray-500">이름</h3>
+          {isEditing.name ? (
+            <div className="flex gap-2 mt-2">
+              <input
+                type="text"
+                value={userInfo.name}
+                onChange={(e) =>
+                  setUserInfo((prev) => ({ ...prev, name: e.target.value }))
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+              <button
+                onClick={handleSaveName}
+                className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+              >
+                저장
+              </button>
+              <button
+                onClick={() => {
+                  setUserInfo((prev) => ({ ...prev, name: loginUser.name })); // 초기 값으로 복원
+                  setIsEditing((prev) => ({ ...prev, name: false })); // 수정 모드 종료
+                }}
+                className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
+              >
+                취소
+              </button>
+            </div>
+          ) : (
+            <div className="flex justify-between items-center mt-2">
+              <p className="text-lg font-semibold text-gray-800">
+                {userInfo.name}
+              </p>
+              <button
+                onClick={() =>
+                  setIsEditing((prev) => ({ ...prev, name: true }))
+                }
+                className="text-blue-500"
+              >
+                수정
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* 이메일 */}
+        <div className="p-4 bg-gray-50 rounded-lg shadow-sm">
+          <h3 className="text-sm font-medium text-gray-500">이메일</h3>
+          {isEditing.email ? (
+            <div className="flex gap-2 mt-2">
+              <input
+                type="email"
+                value={userInfo.email}
+                onChange={(e) =>
+                  setUserInfo((prev) => ({ ...prev, email: e.target.value }))
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+              <button
+                onClick={handleSaveEmail}
+                className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+              >
+                저장
+              </button>
+              <button
+                onClick={() => {
+                  setUserInfo((prev) => ({ ...prev, email: loginUser.email })); // 초기 값으로 복원
+                  setIsEditing((prev) => ({ ...prev, email: false })); // 수정 모드 종료
+                }}
+                className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
+              >
+                취소
+              </button>
+            </div>
+          ) : (
+            <div className="flex justify-between items-center mt-2">
+              <p className="text-lg font-semibold text-gray-800">
+                {userInfo.email}
+              </p>
+              <button
+                onClick={() =>
+                  setIsEditing((prev) => ({ ...prev, email: true }))
+                }
+                className="text-blue-500"
+              >
+                수정
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* 핸드폰 번호 */}
+        <div className="p-4 bg-gray-50 rounded-lg shadow-sm">
+          <h3 className="text-sm font-medium text-gray-500">핸드폰 번호</h3>
+          {isEditing.phoneNumber ? (
+            <div className="flex gap-2 mt-2">
+              <input
+                type="text"
+                value={userInfo.phoneNumber}
+                onChange={(e) =>
+                  setUserInfo((prev) => ({
+                    ...prev,
+                    phoneNumber: e.target.value,
+                  }))
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                placeholder="010-1234-5678"
+              />
+              <button
+                onClick={handleSavePhoneNumber}
+                className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+              >
+                저장
+              </button>
+              <button
+                onClick={() => {
+                  setUserInfo((prev) => ({
+                    ...prev,
+                    phoneNumber: loginUser.phoneNumber,
+                  })); // 초기 값으로 복원
+                  setIsEditing((prev) => ({ ...prev, phoneNumber: false })); // 수정 모드 종료
+                }}
+                className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
+              >
+                취소
+              </button>
+            </div>
+          ) : (
+            <div className="flex justify-between items-center mt-2">
+              <p className="text-lg font-semibold text-gray-800">
+                {userInfo.phoneNumber}
+              </p>
+              <button
+                onClick={() =>
+                  setIsEditing((prev) => ({ ...prev, phoneNumber: true }))
+                }
+                className="text-blue-500"
+              >
+                수정
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* 비밀번호 변경 */}
+        <div className="p-4 bg-gray-50 rounded-lg shadow-sm">
+          <h3 className="text-sm font-medium text-gray-500">비밀번호 변경</h3>
+          <div className="flex flex-col gap-4 mt-2">
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              placeholder="현재 비밀번호"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+            />
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="새 비밀번호"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+            />
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="새 비밀번호 확인"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+            />
+            <button
+              onClick={handlePasswordChange}
+              className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+            >
+              변경
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/user/page.tsx
+++ b/frontend/src/app/user/page.tsx
@@ -36,6 +36,7 @@ const UserProfilePage = () => {
     name: false,
     email: false,
     phoneNumber: false,
+    password: false,
   });
 
   const [newPassword, setNewPassword] = useState("");
@@ -573,35 +574,62 @@ const UserProfilePage = () => {
         {/* 비밀번호 변경 */}
         <div className="p-4 bg-gray-50 rounded-lg shadow-sm">
           <h3 className="text-sm font-medium text-gray-500">비밀번호 변경</h3>
-          <div className="flex flex-col gap-4 mt-2">
-            <input
-              type="password"
-              value={currentPassword}
-              onChange={(e) => setCurrentPassword(e.target.value)}
-              placeholder="현재 비밀번호"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg"
-            />
-            <input
-              type="password"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              placeholder="새 비밀번호"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg"
-            />
-            <input
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              placeholder="새 비밀번호 확인"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg"
-            />
-            <button
-              onClick={handlePasswordChange}
-              className="px-4 py-2 bg-blue-500 text-white rounded-lg"
-            >
-              변경
-            </button>
-          </div>
+          {isEditing.password ? (
+            <div className="flex flex-col gap-4 mt-2">
+              <input
+                type="password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                placeholder="현재 비밀번호"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+              <input
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                placeholder="새 비밀번호"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+              <input
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="새 비밀번호 확인"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={handlePasswordChange}
+                  className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+                >
+                  변경
+                </button>
+                <button
+                  onClick={() => {
+                    setIsEditing((prev) => ({ ...prev, password: false })); // 수정 모드 종료
+                    setCurrentPassword("");
+                    setNewPassword("");
+                    setConfirmPassword("");
+                  }}
+                  className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
+                >
+                  취소
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex justify-between items-center mt-2">
+              <p className="text-lg font-semibold text-gray-800">********</p>
+              <button
+                onClick={() =>
+                  setIsEditing((prev) => ({ ...prev, password: true }))
+                }
+                className="text-blue-500"
+              >
+                수정
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/app/user/page.tsx
+++ b/frontend/src/app/user/page.tsx
@@ -61,6 +61,41 @@ const UserProfilePage = () => {
     }
   };
 
+  const handleSaveEmail = async () => {
+    const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+    // 유효성 검사
+    if (!userInfo.email.trim()) {
+      alert("이메일을 입력해주세요.");
+      return;
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(userInfo.email)) {
+      alert("유효한 이메일 형식이 아닙니다.");
+      return;
+    }
+
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/users/email`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({ email: userInfo.email }),
+      });
+
+      if (!response.ok) throw new Error("이메일을 수정할 수 없습니다.");
+
+      const data = await response.json();
+      alert("이메일이 성공적으로 수정되었습니다.");
+      setUserInfo((prev) => ({ ...prev, email: data.data.email }));
+      setIsEditing((prev) => ({ ...prev, email: false }));
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "오류가 발생했습니다.");
+    }
+  };
+
   const handleSave = async (field: string, value: string) => {
     try {
       const response = await fetch(`/api/v1/user/${field}`, {
@@ -197,7 +232,7 @@ const UserProfilePage = () => {
               className="w-full px-4 py-3 border border-gray-300 rounded-lg"
             />
             <button
-              onClick={() => handleSave("email", userInfo.email)}
+              onClick={handleSaveEmail}
               className="px-4 py-2 bg-blue-500 text-white rounded-lg"
             >
               저장

--- a/frontend/src/app/user/page.tsx
+++ b/frontend/src/app/user/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useState } from "react";
+import { useGlobalLoginUser } from "@/stores/auth/loginMember";
+
+const UserProfilePage = () => {
+  const { loginUser } = useGlobalLoginUser(); // 현재 로그인한 유저 정보
+
+  const [userInfo, setUserInfo] = useState({
+    managementPageName: loginUser.managementDashboardName || "",
+    departmentName: loginUser.departmentName || "",
+    name: loginUser.name || "",
+    email: loginUser.email || "",
+    phoneNumber: loginUser.phoneNumber || "",
+  });
+
+  const [isEditing, setIsEditing] = useState({
+    name: false,
+    email: false,
+    phoneNumber: false,
+  });
+
+  const [newPassword, setNewPassword] = useState("");
+
+  const handleSaveName = async () => {
+    const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+    // 유효성 검사
+    if (!userInfo.name.trim()) {
+      alert("이름을 입력해주세요.");
+      return;
+    }
+    if (userInfo.name.length > 20) {
+      alert("이름은 최대 20자까지 가능합니다.");
+      return;
+    }
+    const nameRegex = /^[가-힣]+$/;
+    if (!nameRegex.test(userInfo.name)) {
+      alert("이름은 한글만 입력 가능합니다.");
+      return;
+    }
+
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/users/name`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({ name: userInfo.name }),
+      });
+
+      if (!response.ok) throw new Error("이름을 수정할 수 없습니다.");
+
+      const data = await response.json();
+      alert("이름이 성공적으로 수정되었습니다.");
+      setUserInfo((prev) => ({ ...prev, name: data.data.name }));
+      setIsEditing((prev) => ({ ...prev, name: false }));
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "오류가 발생했습니다.");
+    }
+  };
+
+  const handleSave = async (field: string, value: string) => {
+    try {
+      const response = await fetch(`/api/v1/user/${field}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({ [field]: value }),
+      });
+
+      if (!response.ok) throw new Error("정보를 업데이트할 수 없습니다.");
+
+      alert(`${field}이(가) 성공적으로 수정되었습니다.`);
+      setUserInfo((prev) => ({ ...prev, [field]: value }));
+      setIsEditing((prev) => ({ ...prev, [field]: false }));
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "오류가 발생했습니다.");
+    }
+  };
+
+  const handlePasswordChange = async () => {
+    if (!newPassword) {
+      alert("새 비밀번호를 입력해주세요.");
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/v1/user/password`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+        body: JSON.stringify({ password: newPassword }),
+      });
+
+      if (!response.ok) throw new Error("비밀번호를 변경할 수 없습니다.");
+
+      alert("비밀번호가 성공적으로 변경되었습니다.");
+      setNewPassword("");
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "오류가 발생했습니다.");
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-8 bg-white shadow-lg rounded-lg mt-12">
+      <h1 className="text-4xl font-bold text-center mb-12 text-gray-800">
+        회원 정보 관리
+      </h1>
+
+      {/* 관리 페이지 이름 */}
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700">
+          관리 페이지 이름
+        </label>
+        <input
+          type="text"
+          value={userInfo.managementPageName}
+          disabled
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-gray-100 text-gray-600 cursor-not-allowed"
+        />
+      </div>
+
+      {/* 부서 이름 */}
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700">
+          부서 이름
+        </label>
+        <input
+          type="text"
+          value={userInfo.departmentName}
+          disabled
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-gray-100 text-gray-600 cursor-not-allowed"
+        />
+      </div>
+
+      {/* 이름 */}
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700">이름</label>
+        {isEditing.name ? (
+          <div className="flex gap-4">
+            <input
+              type="text"
+              value={userInfo.name}
+              onChange={(e) =>
+                setUserInfo((prev) => ({ ...prev, name: e.target.value }))
+              }
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+            />
+            <button
+              onClick={handleSaveName}
+              className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+            >
+              저장
+            </button>
+            <button
+              onClick={() => {
+                setUserInfo((prev) => ({ ...prev, name: loginUser.name })); // 초기 값으로 복원
+                setIsEditing((prev) => ({ ...prev, name: false })); // 수정 모드 종료
+              }}
+              className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
+            >
+              취소
+            </button>
+          </div>
+        ) : (
+          <div className="flex justify-between items-center">
+            <span>{userInfo.name}</span>
+            <button
+              onClick={() => setIsEditing((prev) => ({ ...prev, name: true }))}
+              className="text-blue-500"
+            >
+              수정
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 이메일 */}
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700">
+          이메일
+        </label>
+        {isEditing.email ? (
+          <div className="flex gap-4">
+            <input
+              type="email"
+              value={userInfo.email}
+              onChange={(e) =>
+                setUserInfo((prev) => ({ ...prev, email: e.target.value }))
+              }
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+            />
+            <button
+              onClick={() => handleSave("email", userInfo.email)}
+              className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+            >
+              저장
+            </button>
+            <button
+              onClick={() => {
+                setUserInfo((prev) => ({ ...prev, email: loginUser.email })); // 초기 값으로 복원
+                setIsEditing((prev) => ({ ...prev, email: false })); // 수정 모드 종료
+              }}
+              className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
+            >
+              취소
+            </button>
+          </div>
+        ) : (
+          <div className="flex justify-between items-center">
+            <span>{userInfo.email}</span>
+            <button
+              onClick={() => setIsEditing((prev) => ({ ...prev, email: true }))}
+              className="text-blue-500"
+            >
+              수정
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 핸드폰 번호 */}
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700">
+          핸드폰 번호
+        </label>
+        {isEditing.phoneNumber ? (
+          <div className="flex gap-4">
+            <input
+              type="text"
+              value={userInfo.phoneNumber}
+              onChange={(e) =>
+                setUserInfo((prev) => ({
+                  ...prev,
+                  phoneNumber: e.target.value,
+                }))
+              }
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+              placeholder="010-1234-5678"
+            />
+            <button
+              onClick={() => handleSave("phoneNumber", userInfo.phoneNumber)}
+              className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+            >
+              저장
+            </button>
+            <button
+              onClick={() => {
+                setUserInfo((prev) => ({
+                  ...prev,
+                  phoneNumber: loginUser.phoneNumber,
+                })); // 초기 값으로 복원
+                setIsEditing((prev) => ({ ...prev, phoneNumber: false })); // 수정 모드 종료
+              }}
+              className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
+            >
+              취소
+            </button>
+          </div>
+        ) : (
+          <div className="flex justify-between items-center">
+            <span>{userInfo.phoneNumber}</span>
+            <button
+              onClick={() =>
+                setIsEditing((prev) => ({ ...prev, phoneNumber: true }))
+              }
+              className="text-blue-500"
+            >
+              수정
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 비밀번호 변경 */}
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700">
+          비밀번호
+        </label>
+        <div className="flex gap-4">
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="새 비밀번호 입력"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+          />
+          <button
+            onClick={handlePasswordChange}
+            className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+          >
+            변경
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserProfilePage;

--- a/frontend/src/app/user/page.tsx
+++ b/frontend/src/app/user/page.tsx
@@ -8,9 +8,16 @@ import {
   updateUserPhoneNumber,
   updateUserPassword,
 } from "@/utils/modifyUser";
+import {
+  checkEmailDuplication,
+  sendAuthCode,
+  verifyAuthCode,
+} from "@/utils/emailValidation";
 
 const UserProfilePage = () => {
   const { loginUser } = useGlobalLoginUser(); // 현재 로그인한 유저 정보
+  const [isEmailLoading, setIsEmailLoading] = useState(false);
+  const [isPhoneLoading, setIsPhoneLoading] = useState(false);
 
   const [userInfo, setUserInfo] = useState({
     managementPageName: loginUser.managementDashboardName || "",
@@ -30,6 +37,12 @@ const UserProfilePage = () => {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [currentPassword, setCurrentPassword] = useState("");
 
+  const [verificationCode, setVerificationCode] = useState("");
+  const [isVerified, setIsVerified] = useState(false);
+  const [isEmailChecked, setIsEmailChecked] = useState(false);
+  const [authCodeSent, setAuthCodeSent] = useState(false);
+  const [timer, setTimer] = useState(300); // 5분 타이머
+
   const handleSaveName = async () => {
     try {
       const data = await updateUserName(userInfo.name);
@@ -41,12 +54,70 @@ const UserProfilePage = () => {
     }
   };
 
+  const isValidEmailFormat = (email: string) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  const handleVerifyEmail = async () => {
+    if (!userInfo.email || !isValidEmailFormat(userInfo.email)) {
+      alert("올바른 이메일 형식을 입력해주세요.");
+      return;
+    }
+
+    try {
+      setIsEmailLoading(true);
+      await checkEmailDuplication(userInfo.email);
+      alert("사용 가능한 이메일입니다.");
+      setIsEmailChecked(true);
+
+      await sendAuthCode(userInfo.email);
+      alert("인증 코드가 발송되었습니다.");
+      setAuthCodeSent(true);
+
+      // 2분 타이머 시작
+      let timeLeft = 120;
+      setTimer(timeLeft);
+      const timerInterval = setInterval(() => {
+        timeLeft -= 1;
+        setTimer(timeLeft);
+        if (timeLeft <= 0) {
+          clearInterval(timerInterval);
+          setAuthCodeSent(false);
+        }
+      }, 1000);
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "오류가 발생했습니다.");
+      setIsEmailChecked(false); // 실패 시 재확인 가능하게
+    } finally {
+      setIsEmailLoading(false);
+    }
+  };
+
+  const handleConfirmCode = async () => {
+    try {
+      // 인증 코드 확인
+      await verifyAuthCode(userInfo.email, verificationCode);
+      alert("인증이 완료되었습니다.");
+      setIsVerified(true);
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "오류가 발생했습니다.");
+    }
+  };
+
   const handleSaveEmail = async () => {
+    if (!isVerified) {
+      alert("이메일 인증을 완료해주세요.");
+      return;
+    }
+
     try {
       const data = await updateUserEmail(userInfo.email);
       alert("이메일이 성공적으로 수정되었습니다.");
       setUserInfo((prev) => ({ ...prev, email: data.data.email }));
       setIsEditing((prev) => ({ ...prev, email: false }));
+      setIsVerified(false); // 인증 상태 초기화
+      setIsEmailChecked(false); // 이메일 중복 확인 상태 초기화
     } catch (error) {
       alert(error instanceof Error ? error.message : "오류가 발생했습니다.");
     }
@@ -169,30 +240,109 @@ const UserProfilePage = () => {
         <div className="p-4 bg-gray-50 rounded-lg shadow-sm">
           <h3 className="text-sm font-medium text-gray-500">이메일</h3>
           {isEditing.email ? (
-            <div className="flex gap-2 mt-2">
-              <input
-                type="email"
-                value={userInfo.email}
-                onChange={(e) =>
-                  setUserInfo((prev) => ({ ...prev, email: e.target.value }))
-                }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
-              />
-              <button
-                onClick={handleSaveEmail}
-                className="px-4 py-2 bg-blue-500 text-white rounded-lg"
-              >
-                저장
-              </button>
-              <button
-                onClick={() => {
-                  setUserInfo((prev) => ({ ...prev, email: loginUser.email })); // 초기 값으로 복원
-                  setIsEditing((prev) => ({ ...prev, email: false })); // 수정 모드 종료
-                }}
-                className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
-              >
-                취소
-              </button>
+            <div className="flex flex-col gap-4 mt-2">
+              {/* 이메일 입력 */}
+              <div className="flex items-center">
+                <input
+                  type="email"
+                  value={userInfo.email}
+                  onChange={(e) =>
+                    setUserInfo((prev) => ({ ...prev, email: e.target.value }))
+                  }
+                  disabled={isVerified || isEmailChecked} // 중복 확인 완료 시 비활성화
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none"
+                  placeholder="이메일을 입력하세요"
+                />
+                <button
+                  type="button"
+                  onClick={handleVerifyEmail}
+                  disabled={isVerified || isEmailChecked || isEmailLoading}
+                  className={`ml-3 px-4 py-2 rounded-lg text-white text-sm min-w-[100px] ${
+                    isVerified || isEmailChecked || isEmailLoading
+                      ? "bg-gray-400"
+                      : "bg-blue-500 hover:bg-blue-600"
+                  }`}
+                >
+                  {isEmailLoading
+                    ? "로딩중..."
+                    : isVerified
+                    ? "완료됨"
+                    : isEmailChecked
+                    ? "중복 확인 완료"
+                    : "중복 확인"}
+                </button>
+              </div>
+              {isVerified && (
+                <p className="text-sm mt-1 text-blue-500">
+                  이메일 인증이 완료되었습니다.
+                </p>
+              )}
+
+              {/* 인증번호 입력 */}
+              {isEmailChecked && !isVerified && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-500 mb-1">
+                    이메일 인증
+                  </label>
+                  <div className="flex items-center">
+                    <input
+                      type="text"
+                      value={verificationCode}
+                      onChange={(e) => setVerificationCode(e.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none"
+                      placeholder="인증번호를 입력하세요"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleConfirmCode}
+                      className="ml-3 px-4 py-2 rounded-lg bg-blue-500 text-white text-sm min-w-[100px] hover:bg-blue-600"
+                    >
+                      인증
+                    </button>
+                  </div>
+                  {authCodeSent && (
+                    <p className="text-xs text-gray-500 mt-1">
+                      남은 시간: {Math.floor(timer / 60)}:
+                      {String(timer % 60).padStart(2, "0")}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {/* 저장 및 취소 버튼 */}
+              <div className="flex gap-2 mt-4">
+                <button
+                  onClick={() => {
+                    if (!isEmailChecked) {
+                      alert("이메일 중복 확인이 완료되지 않았습니다.");
+                      return;
+                    }
+                    if (!isVerified) {
+                      alert("이메일 인증이 완료되지 않았습니다.");
+                      return;
+                    }
+                    handleSaveEmail();
+                  }}
+                  className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+                  //disabled={!isEmailChecked || !isVerified} // 버튼 비활성화 조건 추가
+                >
+                  저장
+                </button>
+                <button
+                  onClick={() => {
+                    setUserInfo((prev) => ({
+                      ...prev,
+                      email: loginUser.email,
+                    })); // 초기 값으로 복원
+                    setIsEditing((prev) => ({ ...prev, email: false })); // 수정 모드 종료
+                    setIsVerified(false); // 인증 상태 초기화
+                    setIsEmailChecked(false); // 이메일 중복 확인 상태 초기화
+                  }}
+                  className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg"
+                >
+                  취소
+                </button>
+              </div>
             </div>
           ) : (
             <div className="flex justify-between items-center mt-2">

--- a/frontend/src/app/user/page.tsx
+++ b/frontend/src/app/user/page.tsx
@@ -96,22 +96,36 @@ const UserProfilePage = () => {
     }
   };
 
-  const handleSave = async (field: string, value: string) => {
+  const handleSavePhoneNumber = async () => {
+    const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+    // 유효성 검사
+    if (!userInfo.phoneNumber.trim()) {
+      alert("핸드폰 번호를 입력해주세요.");
+      return;
+    }
+    const phoneRegex = /^010-\d{4}-\d{4}$/;
+    if (!phoneRegex.test(userInfo.phoneNumber)) {
+      alert("전화번호 형식은 010-1234-5678이어야 합니다.");
+      return;
+    }
+
     try {
-      const response = await fetch(`/api/v1/user/${field}`, {
+      const response = await fetch(`${API_BASE}/api/v1/users/phoneNumber`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
         },
         credentials: "include",
-        body: JSON.stringify({ [field]: value }),
+        body: JSON.stringify({ phoneNumber: userInfo.phoneNumber }),
       });
 
-      if (!response.ok) throw new Error("정보를 업데이트할 수 없습니다.");
+      if (!response.ok) throw new Error("핸드폰 번호를 수정할 수 없습니다.");
 
-      alert(`${field}이(가) 성공적으로 수정되었습니다.`);
-      setUserInfo((prev) => ({ ...prev, [field]: value }));
-      setIsEditing((prev) => ({ ...prev, [field]: false }));
+      const data = await response.json();
+      alert("핸드폰 번호가 성공적으로 수정되었습니다.");
+      setUserInfo((prev) => ({ ...prev, phoneNumber: data.data.phoneNumber }));
+      setIsEditing((prev) => ({ ...prev, phoneNumber: false }));
     } catch (error) {
       alert(error instanceof Error ? error.message : "오류가 발생했습니다.");
     }
@@ -280,7 +294,7 @@ const UserProfilePage = () => {
               placeholder="010-1234-5678"
             />
             <button
-              onClick={() => handleSave("phoneNumber", userInfo.phoneNumber)}
+              onClick={handleSavePhoneNumber}
               className="px-4 py-2 bg-blue-500 text-white rounded-lg"
             >
               저장

--- a/frontend/src/utils/modifyUser.ts
+++ b/frontend/src/utils/modifyUser.ts
@@ -6,8 +6,8 @@ export const updateUserName = async (name: string) => {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
     },
+    credentials: "include",
     body: JSON.stringify({ name }),
   });
 
@@ -24,8 +24,8 @@ export const updateUserEmail = async (email: string) => {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
     },
+    credentials: "include",
     body: JSON.stringify({ email }),
   });
 
@@ -42,8 +42,8 @@ export const updateUserPhoneNumber = async (phoneNumber: string) => {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
     },
+    credentials: "include",
     body: JSON.stringify({ phoneNumber }),
   });
 
@@ -63,8 +63,8 @@ export const updateUserPassword = async (
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
     },
+    credentials: "include",
     body: JSON.stringify({ beforePassword, changePassword }),
   });
 

--- a/frontend/src/utils/modifyUser.ts
+++ b/frontend/src/utils/modifyUser.ts
@@ -1,0 +1,79 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+// 이름 수정 API
+export const updateUserName = async (name: string) => {
+  const response = await fetch(`${API_BASE}/api/v1/users/name`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+    },
+    body: JSON.stringify({ name }),
+  });
+
+  if (!response.ok) {
+    throw new Error("이름을 수정할 수 없습니다.");
+  }
+
+  return response.json();
+};
+
+// 이메일 수정 API
+export const updateUserEmail = async (email: string) => {
+  const response = await fetch(`${API_BASE}/api/v1/users/email`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+    },
+    body: JSON.stringify({ email }),
+  });
+
+  if (!response.ok) {
+    throw new Error("이메일을 수정할 수 없습니다.");
+  }
+
+  return response.json();
+};
+
+// 핸드폰 번호 수정 API
+export const updateUserPhoneNumber = async (phoneNumber: string) => {
+  const response = await fetch(`${API_BASE}/api/v1/users/phoneNumber`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+    },
+    body: JSON.stringify({ phoneNumber }),
+  });
+
+  if (!response.ok) {
+    throw new Error("핸드폰 번호를 수정할 수 없습니다.");
+  }
+
+  return response.json();
+};
+
+// 비밀번호 변경 API
+export const updateUserPassword = async (
+  beforePassword: string,
+  changePassword: string
+) => {
+  const response = await fetch(`${API_BASE}/api/v1/users/password`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+    },
+    body: JSON.stringify({ beforePassword, changePassword }),
+  });
+
+  if (!response.ok) {
+    if (response.status === 400) {
+      throw new Error("이전 비밀번호가 틀립니다.");
+    }
+    throw new Error("비밀번호를 변경할 수 없습니다.");
+  }
+
+  return response.json();
+};


### PR DESCRIPTION
## 📒 개요

회원 마이페이지 구현 

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->

> closed #Issue_number
#248 
<br>

## 🛠️ 작업사항

- 이메일 인증 후 이메일 수정 기능 구현
- 핸드폰 인증 후 핸드폰 번호 수정 기능 구현
- 이름, 비밀번호 수정 기능 구현
- 인증번호 타이머 및 중복 확인 로직 추가
- 입력값 검증 및 상태 초기화 처리
- 사용자 정보 UI 개선 (Tailwind 적용)


<br>

## 📸 스크린샷(선택)
<img width="967" alt="스크린샷 2025-05-26 오전 4 47 30" src="https://github.com/user-attachments/assets/29509a8a-a26c-400e-9365-ce5b02bbad33" />

