### PR TITLE
[ front / feat ] 319 : 사용자 리스트로 승인, 거부, 삭제 구현

### DIFF
--- a/frontend/src/app/settings/approve/page.tsx
+++ b/frontend/src/app/settings/approve/page.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, ChangeEvent } from "react";
 import { fetchUsersByStatus } from "@/utils/statusUserList";
 import { useGlobalLoginUser } from "@/stores/auth/loginMember";
 import Link from "next/link";
 
 export default function ApprovePage() {
-  const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const { loginUser } = useGlobalLoginUser();
   const managementDashboardName = loginUser.managementDashboardName;
@@ -26,6 +25,7 @@ export default function ApprovePage() {
   const [filterStatus, setFilterStatus] = useState<
     "approve" | "reject" | "request"
   >("approve");
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
   useEffect(() => {
     const checkInitialManager = async () => {
@@ -69,14 +69,38 @@ export default function ApprovePage() {
         );
 
         setUsers(filteredUsers);
+        setSelectedIds([]); // 목록 갱신 시 선택 초기화
       } catch (error) {
         console.error(error);
       }
     };
 
     fetchUsers();
-  }, [filterStatus, selectedRole, managementDashboardName, currentPage]);
+  }, [
+    filterStatus,
+    selectedRole,
+    managementDashboardName,
+    currentPage,
+    loginUser.id,
+  ]);
 
+  // 체크박스 핸들러
+  const handleSelect = (e: ChangeEvent<HTMLInputElement>, userId: number) => {
+    if (e.target.checked) {
+      setSelectedIds((prev) => [...prev, userId]);
+    } else {
+      setSelectedIds((prev) => prev.filter((id) => id !== userId));
+    }
+  };
+
+  const handleSelectAll = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.checked) {
+      const allIds = users.map((user) => user.userId);
+      setSelectedIds(allIds);
+    } else {
+      setSelectedIds([]);
+    }
+  };
   const handleDelete = async (userId: number) => {
     try {
       await fetch(
@@ -114,13 +138,64 @@ export default function ApprovePage() {
     }
   };
 
+  // 배치 처리 핸들러들
+  const handleBatchApprove = async () => {
+    try {
+      await Promise.all(
+        selectedIds.map((id) =>
+          fetch(
+            `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/users/approve/${id}`,
+            { method: "POST", credentials: "include" }
+          )
+        )
+      );
+      alert("승인되었습니다.");
+      location.reload();
+    } catch (error) {
+      alert("승인 처리 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleBatchReject = async () => {
+    try {
+      await Promise.all(
+        selectedIds.map((id) =>
+          fetch(
+            `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/users/reject/${id}`,
+            { method: "POST", credentials: "include" }
+          )
+        )
+      );
+      alert("거부되었습니다.");
+      location.reload();
+    } catch (error) {
+      alert("거부 처리 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleBatchDelete = async () => {
+    try {
+      await Promise.all(
+        selectedIds.map((id) =>
+          fetch(
+            `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/users/delete/${id}`,
+            { method: "PATCH", credentials: "include" }
+          )
+        )
+      );
+      alert("삭제되었습니다.");
+      location.reload();
+    } catch (error) {
+      alert("삭제 처리 중 오류가 발생했습니다.");
+    }
+  };
+
   return (
     <div className="p-6 bg-white">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-[#0047AB]">
           {selectedRole === "회원" ? "사용자 관리" : "매니저 관리"}
         </h1>
-
         <Link
           href="/settings/approve/search"
           className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600"
@@ -178,9 +253,65 @@ export default function ApprovePage() {
         </button>
       </div>
 
+      {/* 배치 처리 버튼 영역 */}
+      {selectedIds.length > 0 && (
+        <div className="mb-4 flex space-x-4">
+          {filterStatus === "approve" && (
+            <button
+              onClick={handleBatchReject}
+              className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
+            >
+              선택한 유저 거부
+            </button>
+          )}
+          {filterStatus === "reject" && (
+            <>
+              <button
+                onClick={handleBatchApprove}
+                className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600"
+              >
+                선택한 유저 승인
+              </button>
+              <button
+                onClick={handleBatchDelete}
+                className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600"
+              >
+                선택한 유저 삭제
+              </button>
+            </>
+          )}
+          {filterStatus === "request" && (
+            <>
+              <button
+                onClick={handleBatchApprove}
+                className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600"
+              >
+                선택한 유저 승인
+              </button>
+              <button
+                onClick={handleBatchReject}
+                className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
+              >
+                선택한 유저 거부
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
       <table className="w-full border-collapse border border-gray-200">
         <thead>
           <tr className="bg-gray-100">
+            {/* 추가: 체크박스 헤더 */}
+            <th className="border border-gray-200 px-4 py-2">
+              <input
+                type="checkbox"
+                onChange={handleSelectAll}
+                checked={
+                  users.length > 0 && selectedIds.length === users.length
+                }
+              />
+            </th>
             <th className="border border-gray-200 px-4 py-2 text-left">번호</th>
             <th className="border border-gray-200 px-4 py-2 text-left">
               이메일
@@ -192,7 +323,6 @@ export default function ApprovePage() {
             <th className="border border-gray-200 px-4 py-2 text-left">
               부서 이름
             </th>
-            {/* 부서 이름 추가 */}
             <th className="border border-gray-200 px-4 py-2 text-left">
               요청일
             </th>
@@ -201,81 +331,112 @@ export default function ApprovePage() {
           </tr>
         </thead>
         <tbody>
-          {users.map((user: any, index: number) => (
-            <tr key={index} className="hover:bg-gray-50">
-              <td className="border border-gray-200 px-4 py-2">{index + 1}</td>
-              <td className="border border-gray-200 px-4 py-2">{user.email}</td>
-              <td className="border border-gray-200 px-4 py-2">{user.name}</td>
-              <td className="border border-gray-200 px-4 py-2">
-                {user.phoneNumber}
-              </td>
-              <td className="border border-gray-200 px-4 py-2">
-                {user.departmentName || "N/A"}
-              </td>
-              {/* 부서 이름 추가 */}
-              <td className="border border-gray-200 px-4 py-2">
-                {new Date(user.requestDate).toLocaleString("ko-KR", {
-                  year: "numeric",
-                  month: "2-digit",
-                  day: "2-digit",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
-              </td>
-              <td className="border border-gray-200 px-4 py-2">
-                {user.approvalStatus}
-              </td>
-              <td className="border border-gray-200 px-4 py-2 flex space-x-2">
-                {filterStatus === "request" && (
-                  <>
-                    <button
-                      onClick={() => handleApprove(user.userId)}
-                      className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600"
-                    >
-                      승인
-                    </button>
-                    <button
-                      onClick={() => handleReject(user.userId)}
-                      className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
-                    >
-                      거부
-                    </button>
-                  </>
-                )}
-
-                {filterStatus === "approve" &&
-                  (user.approvalStatus === "REJECTED" ? (
-                    <span className="px-4 py-2 bg-blue-500 text-white rounded-lg">
-                      거부됨
-                    </span>
-                  ) : (
-                    <button
-                      onClick={() => handleReject(user.userId)}
-                      className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
-                    >
-                      거부
-                    </button>
-                  ))}
-
-                {filterStatus === "reject" && (
-                  <>
-                    <button
-                      onClick={() => handleApprove(user.userId)}
-                      className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600"
-                    >
-                      승인
-                    </button>
-                    <button
-                      onClick={() => handleDelete(user.userId)} // 삭제 핸들러가 필요하다면 정의해야 함
-                      className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600"
-                    >
-                      삭제
-                    </button>
-                  </>
-                )}
+          {users.length === 0 ? (
+            <tr>
+              <td colSpan={9} className="text-center py-8 text-gray-400">
+                검색 결과가 없습니다.
               </td>
             </tr>
-          ))}
+          ) : (
+            users.map((user: any, index: number) => (
+              <tr key={user.userId} className="hover:bg-gray-50">
+                {/* 체크박스 */}
+                <td className="border border-gray-200 px-4 py-2">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(user.userId)}
+                    onChange={(e) => handleSelect(e, user.userId)}
+                  />
+                </td>
+                <td className="border border-gray-200 px-4 py-2">
+                  {index + 1}
+                </td>
+                <td className="border border-gray-200 px-4 py-2">
+                  {user.email}
+                </td>
+                <td className="border border-gray-200 px-4 py-2">
+                  {user.name}
+                </td>
+                <td className="border border-gray-200 px-4 py-2">
+                  {user.phoneNumber}
+                </td>
+                <td className="border border-gray-200 px-4 py-2">
+                  {user.departmentName || "N/A"}
+                </td>
+                <td className="border border-gray-200 px-4 py-2">
+                  {new Date(user.requestDate).toLocaleString("ko-KR", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </td>
+                <td className="border border-gray-200 px-4 py-2">
+                  {user.approvalStatus}
+                </td>
+                <td className="border border-gray-200 px-4 py-2 flex space-x-2">
+                  {filterStatus === "request" && (
+                    <>
+                      <button
+                        onClick={() => {
+                          handleApprove(user.userId);
+                        }}
+                        className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600"
+                      >
+                        승인
+                      </button>
+                      <button
+                        onClick={() => {
+                          handleReject(user.userId);
+                        }}
+                        className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
+                      >
+                        거부
+                      </button>
+                    </>
+                  )}
+
+                  {filterStatus === "approve" &&
+                    (user.approvalStatus === "REJECTED" ? (
+                      <span className="px-4 py-2 bg-blue-500 text-white rounded-lg">
+                        거부됨
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => {
+                          handleReject(user.userId);
+                        }}
+                        className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
+                      >
+                        거부
+                      </button>
+                    ))}
+
+                  {filterStatus === "reject" && (
+                    <>
+                      <button
+                        onClick={() => {
+                          handleApprove(user.userId);
+                        }}
+                        className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600"
+                      >
+                        승인
+                      </button>
+                      <button
+                        onClick={() => {
+                          handleDelete(user.userId);
+                        }}
+                        className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600"
+                      >
+                        삭제
+                      </button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))
+          )}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## 📒 개요

배치 처리 기능 추가: 여러 명 선택하여 승인, 거부, 삭제 가능

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#319
> closed #Issue_number

<br>

## 🛠️ 작업사항


- 사용자 목록에 체크박스 추가하여 다중 선택 기능 구현
- 필터(요청, 승인, 거부)별 각각 배치 처리 버튼 추가
  - 요청 상태: 선택한 유저 승인/거부
  - 승인 상태: 선택한 유저 거부
  - 거부 상태: 선택한 유저 승인/삭제
- API 호출 후 페이지 새로고침 처리

<br>

## 📸 스크린샷(선택)
<img width="1200" alt="스크린샷 2025-05-27 오후 5 02 29" src="https://github.com/user-attachments/assets/64aa1a23-5e11-47f7-8099-d45bb837b82b" />
<img width="1200" alt="스크린샷 2025-05-27 오후 5 02 17" src="https://github.com/user-attachments/assets/f390e165-2523-48ed-8bd1-3134dfa142e3" />


