### PR TITLE
[ front / refact ] 337 : 채팅 프론트 시간 표시 타임존 설정

### DIFF
--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -424,6 +424,7 @@ const Chat: React.FC<Props> = ({ roomId, client, loginUserId, onClose }) => {
                       {new Date(msg.createDate).toLocaleTimeString([], {
                         hour: "2-digit",
                         minute: "2-digit",
+                        timeZone: "Asia/Seoul",
                       })}
                     </small>
                   )}


### PR DESCRIPTION
## 📒 개요

채팅 시간 표시 변경 

<br>

## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
#337 
> closed #Issue_number

<br>

## 🛠️ 작업사항

채팅 시간 표시 타임존 설정
timeZone: "Asia/Seoul",

<br>

## 📸 스크린샷(선택)
