### PR TITLE
[ feat ] 520 : k6 prometheus grafana 통합 부하 테스트 환경 구축

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -89,6 +89,10 @@ dependencies {
     //누리고
     implementation("net.nurigo:sdk:4.2.7") // 누리고 SDK
 
+    //프로메테우스
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
+
 }
 
 
@@ -119,4 +123,5 @@ tasks.withType<Test> {
 
 tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
     mainClass.set("com.example.backend.BackendApplication")
+
 }

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -50,6 +50,10 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
+    command:
+      - --web.enable-remote-write-receiver
+      - --enable-feature=native-histograms
+      - --config.file=/etc/prometheus/prometheus.yml
     container_name: juseyo-prometheus
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
@@ -58,7 +62,7 @@ services:
     networks:
       - juseyo-network
     extra_hosts:
-      - "host.docker.internal:host-gateway" # 🔥 이거 추가됨!
+      - "host.docker.internal:host-gateway"
 
   grafana:
     image: grafana/grafana:latest
@@ -80,7 +84,10 @@ services:
       - ./k6:/scripts
     command: run /scripts/load-test.js
     environment:
-      K6_OUT: prometheus
+      K6_OUT: experimental-prometheus-rw
+      K6_PROMETHEUS_RW_SERVER_URL: http://prometheus:9090/api/v1/write
+      K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM: "true"
+
     depends_on:
       - prometheus
       - redis

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3' # Docker Compose 버전 명시
+#version: '3' # Docker Compose 버전 명시
 
 services:
   mysql:
@@ -43,16 +43,42 @@ services:
       context: ./recommendation-app
     container_name: flask-recommender
     ports:
-      - "5000:5000"
+      - "5001:5000"
     restart: unless-stopped
     networks:
       - juseyo-network
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: juseyo-prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - juseyo-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # 🔥 이거 추가됨!
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: juseyo-grafana
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    networks:
+      - juseyo-network
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
 
 
 
 volumes:
   mysql-data:
   redis-data:
+  grafana-data:
 
 networks:
   juseyo-network:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -77,16 +77,17 @@ services:
     image: grafana/k6
     container_name: juseyo-k6
     volumes:
-      - ./k6:/scripts  # k6 테스트 스크립트 디렉토리 마운트
+      - ./k6:/scripts
     command: run /scripts/load-test.js
     environment:
       K6_OUT: prometheus
     depends_on:
-      - juseyo-prometheus
-      - juseyo-redis
-      - juseyo-mysql-container
+      - prometheus
+      - redis
+      - mysql
     networks:
       - juseyo-network
+
 
 
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -73,6 +73,21 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
 
+  k6:
+    image: grafana/k6
+    container_name: juseyo-k6
+    volumes:
+      - ./k6:/scripts  # k6 테스트 스크립트 디렉토리 마운트
+    command: run /scripts/load-test.js
+    environment:
+      K6_OUT: prometheus
+    depends_on:
+      - juseyo-prometheus
+      - juseyo-redis
+      - juseyo-mysql-container
+    networks:
+      - juseyo-network
+
 
 
 volumes:

--- a/backend/k6/load-test.js
+++ b/backend/k6/load-test.js
@@ -3,7 +3,7 @@ import { check, sleep } from 'k6';
 
 export const options = {
     vus: 10, // 가상 유저 10명
-    duration: '30s', // 30초 동안 테스트
+    duration: '1m', // 30초 동안 테스트 -> 30s
 };
 
 export default function () {

--- a/backend/k6/load-test.js
+++ b/backend/k6/load-test.js
@@ -1,0 +1,13 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+    vus: 10, // 가상 유저 10명
+    duration: '30s', // 30초 동안 테스트
+};
+
+export default function () {
+    const res = http.get('http://host.docker.internal:8080/api/v1/some-endpoint');
+    check(res, { 'status was 200': (r) => r.status === 200 });
+    sleep(1); // 1초 대기
+}

--- a/backend/k6/load-test.js
+++ b/backend/k6/load-test.js
@@ -7,7 +7,7 @@ export const options = {
 };
 
 export default function () {
-    const res = http.get('http://host.docker.internal:8080/api/v1/some-endpoint');
+    const res = http.get('http://host.docker.internal:8080/actuator/health');
     check(res, { 'status was 200': (r) => r.status === 200 });
     sleep(1); // 1초 대기
 }

--- a/backend/node_modules/.package-lock.json
+++ b/backend/node_modules/.package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/k6": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/k6/-/k6-0.0.0.tgz",
+      "integrity": "sha512-GAQSWayS2+LjbH5bkRi+pMPYyP1JSp7o+4j58ANZ762N/RH/SdlAT3CHHztnn8s/xgg8kYNM24Gd2IPo9b5W+g==",
+      "license": "AGPL-3.0"
+    }
+  }
+}

--- a/backend/node_modules/k6/package.json
+++ b/backend/node_modules/k6/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "k6",
+  "version": "0.0.0",
+  "description": "Dummy package for autocompleting k6 scripts.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/loadimpact/k6.git"
+  },
+  "author": "Emily Ekberg <emily@loadimpact.com>",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/loadimpact/k6/issues"
+  },
+  "homepage": "https://github.com/loadimpact/k6#readme"
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backend",
+      "version": "1.0.0",
+      "dependencies": {
+        "k6": "^0.0.0"
+      }
+    },
+    "node_modules/k6": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/k6/-/k6-0.0.0.tgz",
+      "integrity": "sha512-GAQSWayS2+LjbH5bkRi+pMPYyP1JSp7o+4j58ANZ762N/RH/SdlAT3CHHztnn8s/xgg8kYNM24Gd2IPo9b5W+g==",
+      "license": "AGPL-3.0"
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/treejh/JUSEYO.git"
+  },
+  "private": true,
+  "dependencies": {
+    "k6": "^0.0.0"
+  }
+}

--- a/backend/prometheus.yml
+++ b/backend/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s # 15초마다 스크랩
+
+scrape_configs:
+  - job_name: "prometheus"
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ["host.docker.internal:8080"]
+## Prometheus가 로컬(Spring Boot 앱) localhost:8080을 직접 접근x
+## 도커 컨테이너 → 로컬 호스트 통신은 host.docker.internal 사용

--- a/backend/prometheus.yml
+++ b/backend/prometheus.yml
@@ -8,3 +8,7 @@ scrape_configs:
       - targets: ["host.docker.internal:8080"]
 ## Prometheus가 로컬(Spring Boot 앱) localhost:8080을 직접 접근x
 ## 도커 컨테이너 → 로컬 호스트 통신은 host.docker.internal 사용
+  - job_name: 'k6'
+    static_configs:
+      - targets: [ 'k6:5667' ]
+

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -38,7 +38,7 @@ public class SecurityConfigJuseyo {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus","/api/v1/write/**","/api/v1/prom/write/**").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
+++ b/backend/src/main/java/com/example/backend/global/security/config/SecurityConfigJuseyo.java
@@ -38,6 +38,7 @@ public class SecurityConfigJuseyo {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -62,3 +62,20 @@ custom:
     cookieDomain: "${custom.dev.cookieDomain}"
     frontUrl: "${custom.dev.frontUrl}"
     backUrl: "${custom.dev.backUrl}"
+
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+          - metrics
+          - loggers
+          - threaddump
+          - prometheus # 추가
+    metrics:
+      export:
+        prometheus:
+          enabled: true

--- a/backend/src/main/resources/prometheus.yml
+++ b/backend/src/main/resources/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s # 15초마다 스크랩
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+
+## Prometheus가 로컬(Spring Boot 앱) localhost:8080을 직접 접근x
+## 도커 컨테이너 → 로컬 호스트 통신은 host.docker.internal 사용


### PR DESCRIPTION
## 📒 개요  
**k6 + Prometheus + Grafana 통합 부하 테스트 환경 구축**

> 성능 지표 시각화 기반 부하 테스트 환경을 구성하여 서비스의 안정성과 응답성을 정량적으로 분석할 수 있도록 함

---

## 📍 관련 이슈  
> closed #520

---

## 🛠️ 작업 내용  

- `k6`를 사용한 HTTP 부하 테스트 스크립트 작성  
- `Prometheus`를 활용한 k6 지표 수집 설정  
  - remote write 설정 (`--web.enable-remote-write-receiver`)
- `Grafana` 대시보드 생성 및 주요 패널 구성  
  - RPS, 에러율, 응답 시간(P95), 총 요청 수 등 주요 성능 지표 시각화
- `docker-compose`를 통한 전체 환경 구성
  - `k6`, `Prometheus`, `Grafana`, `Redis`, `MySQL` 등 포함

---

## 📸 스크린샷  
<img width="1180" height="723" alt="ㅁㄴㅇㄹ" src="https://github.com/user-attachments/assets/d1964f0f-ad09-4ee5-8b40-5764427fa279" />


