### PR TITLE
[ feat ] 519 : 메시지 조회 시 redis 캐싱 락 도입

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -93,6 +93,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-prometheus")
 
+
+    //redis 분산락 구현
+    implementation("org.redisson:redisson-spring-boot-starter:3.23.1")
+
 }
 
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -96,6 +96,9 @@ dependencies {
 
     //redis 분산락 구현
     implementation("org.redisson:redisson-spring-boot-starter:3.23.1")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+
 
 }
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -82,10 +82,13 @@ services:
     container_name: juseyo-k6
     volumes:
       - ./k6:/scripts
-    command: run /scripts/load-test.js
+    command:
+      - run
+      - --summary-trend-stats=avg,p95,min,max
+      - /scripts/load-test.js
     environment:
       K6_OUT: experimental-prometheus-rw
-      K6_PROMETHEUS_RW_SERVER_URL: http://prometheus:9090/api/v1/write
+      K6_PROMETHEUS_RW_SERVER_URL: http://juseyo-prometheus:9090/api/v1/write
       K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM: "true"
 
     depends_on:

--- a/backend/k6/load-test.js
+++ b/backend/k6/load-test.js
@@ -36,7 +36,7 @@ export function setup() {
 
 export default function (data) {
     const roomId = 1;
-    const page = Math.floor(Math.random() * 3); // page=0~2
+    const page = Math.floor(Math.random() * 5); // page=0~4
 
     const res = http.get(CHAT_ENDPOINT(roomId, page), {
         headers: {

--- a/backend/k6/load-test.js
+++ b/backend/k6/load-test.js
@@ -2,12 +2,54 @@ import http from 'k6/http';
 import { check, sleep } from 'k6';
 
 export const options = {
-    vus: 10, // 가상 유저 10명
-    duration: '1m', // 30초 동안 테스트 -> 30s
+    vus: 100,
+    duration: '10s',
 };
 
-export default function () {
-    const res = http.get('http://host.docker.internal:8080/actuator/health');
-    check(res, { 'status was 200': (r) => r.status === 200 });
-    sleep(1); // 1초 대기
+const BASE_URL = 'http://host.docker.internal:8080';
+const LOGIN_ENDPOINT = `${BASE_URL}/api/v1/users/login`;
+const CHAT_ENDPOINT = (roomId, page, size = 20) => `${BASE_URL}/api/v1/chats/${roomId}?page=${page}&size=${size}`;
+
+// 로그인 후 Authorization 헤더에서 accessToken 추출
+export function setup() {
+    const payload = JSON.stringify({
+        email: 'test@email.com',
+        password: '0b146162-3',
+    });
+
+    const res = http.post(LOGIN_ENDPOINT, payload, {
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+    const authHeader = res.headers['Authorization'];
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        console.error('❌ Authorization 헤더가 없거나 형식이 잘못됨:', authHeader);
+        return;
+    }
+
+    const accessToken = authHeader.replace('Bearer ', '');
+    console.log(`✅ 추출된 accessToken: ${accessToken}`);
+
+    return { accessToken };
 }
+
+export default function (data) {
+    const roomId = 1;
+    const page = Math.floor(Math.random() * 3); // page=0~2
+
+    const res = http.get(CHAT_ENDPOINT(roomId, page), {
+        headers: {
+            'Authorization': `Bearer ${data.accessToken}`,
+        },
+    });
+
+    check(res, {
+        '✅ 200 OK': (r) => r.status === 200,
+        '✅ contains messages': (r) =>
+            r.body && (r.body.includes('message') || r.body.includes('content')),
+    });
+    sleep(1);
+}
+
+

--- a/backend/k6/load-test.js
+++ b/backend/k6/load-test.js
@@ -2,8 +2,13 @@ import http from 'k6/http';
 import { check, sleep } from 'k6';
 
 export const options = {
-    vus: 100,
-    duration: '10s',
+    stages: [
+        { duration: '10s', target: 100 },
+        { duration: '10s', target: 300 },
+        { duration: '10s', target: 500 },
+        { duration: '10s', target: 1000 },
+        { duration: '10s', target: 0 }, // 종료
+    ],
 };
 
 const BASE_URL = 'http://host.docker.internal:8080';

--- a/backend/k6/load-test.js
+++ b/backend/k6/load-test.js
@@ -8,7 +8,7 @@ export const options = {
 
 const BASE_URL = 'http://host.docker.internal:8080';
 const LOGIN_ENDPOINT = `${BASE_URL}/api/v1/users/login`;
-const CHAT_ENDPOINT = (roomId, page, size = 20) => `${BASE_URL}/api/v1/chats/${roomId}?page=${page}&size=${size}`;
+const CHAT_ENDPOINT = (roomId, page, size = 10) => `${BASE_URL}/api/v1/chats/${roomId}?page=${page}&size=${size}`;
 
 // 로그인 후 Authorization 헤더에서 accessToken 추출
 export function setup() {
@@ -36,7 +36,7 @@ export function setup() {
 
 export default function (data) {
     const roomId = 1;
-    const page = Math.floor(Math.random() * 5); // page=0~4
+    const page = Math.floor(Math.random() * 4) + 1; // page = 1~4
 
     const res = http.get(CHAT_ENDPOINT(roomId, page), {
         headers: {
@@ -46,9 +46,23 @@ export default function (data) {
 
     check(res, {
         '✅ 200 OK': (r) => r.status === 200,
-        '✅ contains messages': (r) =>
-            r.body && (r.body.includes('message') || r.body.includes('content')),
+        '✅ 응답 구조 확인 (data.content 존재)': (r) => {
+            try {
+                const json = JSON.parse(r.body);
+                const exists = json.data && Array.isArray(json.data.content);
+                if (!exists) {
+                    // console.error(`❌ content 필드 누락 또는 비정상 구조: ${r.body}`);
+                } else if (json.data.content.length === 0) {
+                    //console.log(`ℹ️ 빈 content 배열 (정상 처리): page=${json.data.pageable?.pageNumber}`);
+                }
+                return exists;
+            } catch (e) {
+                console.error(`❌ JSON 파싱 실패: ${r.body}`);
+                return false;
+            }
+        }
     });
+
     sleep(1);
 }
 

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/controller/ChatMessageController.java
@@ -62,7 +62,6 @@ public class ChatMessageController {
                                             @RequestParam(name = "page", defaultValue = "1") int page,
                                             @RequestParam(name="size", defaultValue = "20") int size) {
 
-
         Page<ChatResponseDto> responseMessage = chatMessageService.getChatMessage(roomId,
                 PageRequest.of(page -1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
 

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/controller/ChatMessageController.java
@@ -62,6 +62,7 @@ public class ChatMessageController {
                                             @RequestParam(name = "page", defaultValue = "1") int page,
                                             @RequestParam(name="size", defaultValue = "20") int size) {
 
+
         Page<ChatResponseDto> responseMessage = chatMessageService.getChatMessage(roomId,
                 PageRequest.of(page -1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
 

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/controller/ChatMessageController.java
@@ -62,10 +62,9 @@ public class ChatMessageController {
                                             @RequestParam(name = "page", defaultValue = "1") int page,
                                             @RequestParam(name="size", defaultValue = "20") int size) {
 
-        Page<ChatMessage> chatMessagePage = chatMessageService.getChatMessage(roomId,
+        Page<ChatResponseDto> responseMessage = chatMessageService.getChatMessage(roomId,
                 PageRequest.of(page -1, size, Sort.by(Sort.Direction.DESC, "createdAt")));
 
-        Page<ChatResponseDto> responseMessage = chatMessagePage.map(ChatResponseDto::new);
         return new ResponseEntity<>(
                 ApiResponse.of(
                         HttpStatus.OK.value(),

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/dto/response/ChatResponseDto.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/dto/response/ChatResponseDto.java
@@ -7,8 +7,10 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class ChatResponseDto {
 

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/entity/ChatMessage.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/entity/ChatMessage.java
@@ -50,7 +50,4 @@ public class ChatMessage extends Auditable {
     @Column(name = "message", nullable = false, length = 100)
     private String message;
 
-
-
-
 }

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -11,6 +11,7 @@ import com.example.backend.domain.chat.chatUser.entity.ChatUser;
 import com.example.backend.domain.chat.chatUser.repository.ChatUserRepository;
 import com.example.backend.domain.chat.chatroom.entity.ChatRoom;
 import com.example.backend.domain.chat.chatroom.service.ChatRoomService;
+import com.example.backend.domain.chat.redis.ChatMessageRedisService;
 import com.example.backend.domain.chat.redis.RedisCacheLock;
 import com.example.backend.enums.ChatMessageStatus;
 import com.example.backend.enums.ChatStatus;
@@ -26,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -48,7 +50,10 @@ public class ChatMessageService {
     private final TokenService tokenService;
 
 
-    private final RedisTemplate redisTemplate;
+    @Autowired
+    private RedisTemplate<String, ChatResponseDto> chatMessageRedisTemplate;
+
+    private final ChatMessageRedisService chatMessageRedisService;
 
     // for 알림
     private final ApplicationEventPublisher eventPublisher;
@@ -163,7 +168,7 @@ public class ChatMessageService {
 //        return chatMessagePage.map(ChatResponseDto::new);
 //    }
 
-    @RedisCacheLock(key = "#roomId")
+    @RedisCacheLock(key = "'chatroom:' + #roomId + ':messages:page:0'")
     public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable) {
         User user = userService.findById(tokenService.getIdFromToken());
         ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
@@ -172,17 +177,23 @@ public class ChatMessageService {
             throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
         }
 
-        String redisKey = "chatroom:" + roomId + ":messages:page:0";
-        List<ChatResponseDto> cached = redisTemplate.opsForList().range(redisKey, 0, -1);
+        String redisKey = chatMessageRedisService.getChatMessageCacheKey(roomId);
+        List<ChatResponseDto> cached = chatMessageRedisTemplate.opsForList().range(redisKey, 0, -1);
+
+        // 락을 잡은 뒤에도 누군가 캐시를 넣었을 수 있으니 다시 확인 (더블 체크)
         if (cached != null && !cached.isEmpty()) {
+            //캐시 HIT일 경우: 가져온 메시지 리스트를 바로 응답
+            //PageImpl은 Spring Data의 페이지 응답 객체
             return new PageImpl<>(cached, pageable, cached.size());
         }
 
+        //아니면 DB에서 조회
         Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom, pageable);
         List<ChatResponseDto> result = chatMessagePage.map(ChatResponseDto::new).toList();
 
-        redisTemplate.opsForList().rightPushAll(redisKey, result.toArray());
-        redisTemplate.expire(redisKey, Duration.ofSeconds(60));
+        chatMessageRedisTemplate.opsForList().rightPushAll(redisKey, result.toArray(new ChatResponseDto[0]));
+        //TTL 설정: 60초 후 캐시 자동 삭제
+        chatMessageRedisTemplate.expire(redisKey, Duration.ofSeconds(chatMessageRedisService.messageTTL));
 
         return new PageImpl<>(result, pageable, result.size());
     }

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -50,9 +50,6 @@ public class ChatMessageService {
     private final TokenService tokenService;
 
 
-    @Autowired
-    private RedisTemplate<String, ChatResponseDto> chatMessageRedisTemplate;
-
     private final ChatMessageRedisService chatMessageRedisService;
 
     // for 알림
@@ -155,8 +152,57 @@ public class ChatMessageService {
         return chatMessageRepository.save(chatMessage);
     }
 
-    @RedisCacheLock(key = "'chatroom:' + #roomId + ':messages:page:0'")
+//    @RedisCacheLock(key = "'chatroom:' + #roomId + ':messages:page:' + #pageable.pageNumber")
+//    public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable) {
+//        User user = userService.findById(tokenService.getIdFromToken());
+//        ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
+//
+//        if (chatUserRepository.findByUserAndChatRoom(user, chatRoom).isEmpty()) {
+//            throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
+//        }
+//
+//        List<ChatResponseDto> cached = chatMessageRedisService.getCachedMessages(roomId,pageable.getPageNumber());
+//
+//        // 락을 잡은 뒤에도 누군가 캐시를 넣었을 수 있으니 다시 확인 (더블 체크)
+//        if (cached != null && !cached.isEmpty()) {
+//            //캐시 HIT일 경우: 가져온 메시지 리스트를 바로 응답
+//            //PageImpl은 Spring Data의 페이지 응답 객체
+//            return new PageImpl<>(cached, pageable, cached.size());
+//        }
+//
+//        //아니면 DB에서 조회
+//        Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom, pageable);
+//        List<ChatResponseDto> result = chatMessagePage.map(ChatResponseDto::new).toList();
+//
+//        //redis에 저장
+//        chatMessageRedisService.cacheMessages(roomId,result,Duration.ofSeconds(chatMessageRedisService.messageTTL),pageable.getPageNumber());
+//
+//        return new PageImpl<>(result, pageable, result.size());
+//    }
+
     public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable) {
+
+        List<ChatResponseDto> cached = chatMessageRedisService.getCachedMessages(roomId, pageable.getPageNumber());
+
+        // 🔁 캐시 HIT → 락 안 거치고 바로 반환
+        if (cached != null && !cached.isEmpty()) {
+            return new PageImpl<>(cached, pageable, cached.size());
+        }
+
+        // 🔒 캐시 MISS → 락 거는 메서드 따로 분리
+        return getChatMessageWithLock(roomId, pageable);
+    }
+
+    @RedisCacheLock(key = "'chatroom:' + #roomId + ':messages:page:' + #pageable.pageNumber")
+    public Page<ChatResponseDto> getChatMessageWithLock(Long roomId, Pageable pageable) {
+        // 이 안에서는 DB 조회 + 캐싱
+
+        //한번 더 체크
+        List<ChatResponseDto> cached = chatMessageRedisService.getCachedMessages(roomId, pageable.getPageNumber());
+        if (cached != null && !cached.isEmpty()) {
+            return new PageImpl<>(cached, pageable, cached.size());
+        }
+
         User user = userService.findById(tokenService.getIdFromToken());
         ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
 
@@ -164,22 +210,10 @@ public class ChatMessageService {
             throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
         }
 
-        List<ChatResponseDto> cached = chatMessageRedisService.getCachedMessages(roomId);
-
-        // 락을 잡은 뒤에도 누군가 캐시를 넣었을 수 있으니 다시 확인 (더블 체크)
-        if (cached != null && !cached.isEmpty()) {
-            //캐시 HIT일 경우: 가져온 메시지 리스트를 바로 응답
-            //PageImpl은 Spring Data의 페이지 응답 객체
-            return new PageImpl<>(cached, pageable, cached.size());
-        }
-
-        //아니면 DB에서 조회
         Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom, pageable);
         List<ChatResponseDto> result = chatMessagePage.map(ChatResponseDto::new).toList();
 
-
-        //redis에 저장
-        chatMessageRedisService.cacheMessages(roomId,result,Duration.ofSeconds(chatMessageRedisService.messageTTL));
+        chatMessageRedisService.cacheMessages(roomId,result,Duration.ofSeconds(chatMessageRedisService.messageTTL),pageable.getPageNumber());
 
         return new PageImpl<>(result, pageable, result.size());
     }

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -153,34 +153,6 @@ public class ChatMessageService {
         return chatMessageRepository.save(chatMessage);
     }
 
-//    @RedisCacheLock(key = "'chatroom:' + #roomId + ':messages:page:' + #pageable.pageNumber")
-//    public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable) {
-//        User user = userService.findById(tokenService.getIdFromToken());
-//        ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
-//
-//        if (chatUserRepository.findByUserAndChatRoom(user, chatRoom).isEmpty()) {
-//            throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
-//        }
-//
-//        List<ChatResponseDto> cached = chatMessageRedisService.getCachedMessages(roomId,pageable.getPageNumber());
-//
-//        // 락을 잡은 뒤에도 누군가 캐시를 넣었을 수 있으니 다시 확인 (더블 체크)
-//        if (cached != null && !cached.isEmpty()) {
-//            //캐시 HIT일 경우: 가져온 메시지 리스트를 바로 응답
-//            //PageImpl은 Spring Data의 페이지 응답 객체
-//            return new PageImpl<>(cached, pageable, cached.size());
-//        }
-//
-//        //아니면 DB에서 조회
-//        Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom, pageable);
-//        List<ChatResponseDto> result = chatMessagePage.map(ChatResponseDto::new).toList();
-//
-//        //redis에 저장
-//        chatMessageRedisService.cacheMessages(roomId,result,Duration.ofSeconds(chatMessageRedisService.messageTTL),pageable.getPageNumber());
-//
-//        return new PageImpl<>(result, pageable, result.size());
-//    }
-
     public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable) {
 
         List<ChatResponseDto> cached = chatMessageRedisService.getCachedMessages(roomId, pageable.getPageNumber());

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -164,8 +164,7 @@ public class ChatMessageService {
             throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
         }
 
-        String redisKey = chatMessageRedisService.getChatMessageCacheKey(roomId);
-        List<ChatResponseDto> cached = chatMessageRedisTemplate.opsForList().range(redisKey, 0, -1);
+        List<ChatResponseDto> cached = chatMessageRedisService.getCachedMessages(roomId);
 
         // 락을 잡은 뒤에도 누군가 캐시를 넣었을 수 있으니 다시 확인 (더블 체크)
         if (cached != null && !cached.isEmpty()) {
@@ -178,9 +177,9 @@ public class ChatMessageService {
         Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom, pageable);
         List<ChatResponseDto> result = chatMessagePage.map(ChatResponseDto::new).toList();
 
-        chatMessageRedisTemplate.opsForList().rightPushAll(redisKey, result.toArray(new ChatResponseDto[0]));
-        //TTL 설정: 60초 후 캐시 자동 삭제
-        chatMessageRedisTemplate.expire(redisKey, Duration.ofSeconds(chatMessageRedisService.messageTTL));
+
+        //redis에 저장
+        chatMessageRedisService.cacheMessages(roomId,result,Duration.ofSeconds(chatMessageRedisService.messageTTL));
 
         return new PageImpl<>(result, pageable, result.size());
     }

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -11,6 +11,7 @@ import com.example.backend.domain.chat.chatUser.entity.ChatUser;
 import com.example.backend.domain.chat.chatUser.repository.ChatUserRepository;
 import com.example.backend.domain.chat.chatroom.entity.ChatRoom;
 import com.example.backend.domain.chat.chatroom.service.ChatRoomService;
+import com.example.backend.domain.chat.redis.RedisCacheLock;
 import com.example.backend.enums.ChatMessageStatus;
 import com.example.backend.enums.ChatStatus;
 import com.example.backend.global.exception.BusinessLogicException;
@@ -20,12 +21,14 @@ import com.example.backend.global.security.jwt.service.TokenService;
 import com.example.backend.domain.user.entity.User;
 import com.example.backend.domain.user.service.UserService;
 import com.example.backend.global.utils.dto.ApiResponse;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -147,24 +150,43 @@ public class ChatMessageService {
         return chatMessageRepository.save(chatMessage);
     }
 
-    public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable){
+//    public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable){
+//        User user = userService.findById(tokenService.getIdFromToken());
+//        ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
+//
+//        //참여중인 채팅방 아니면 메시지 조회 못함
+//        if(chatUserRepository.findByUserAndChatRoom(user,chatRoom).isEmpty()){
+//            throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
+//        }
+//        Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom,pageable);
+//
+//        return chatMessagePage.map(ChatResponseDto::new);
+//    }
+
+    @RedisCacheLock(key = "#roomId")
+    public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable) {
         User user = userService.findById(tokenService.getIdFromToken());
         ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
 
-        //참여중인 채팅방 아니면 메시지 조회 못함
-        if(chatUserRepository.findByUserAndChatRoom(user,chatRoom).isEmpty()){
+        if (chatUserRepository.findByUserAndChatRoom(user, chatRoom).isEmpty()) {
             throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
-        };
-        List<ChatResponseDto> cached = redisTemplate.opsForList().range(key, 0, -1);
-        if (cached != null && !cached.isEmpty()) return cached; // 캐시 HIT
+        }
 
+        String redisKey = "chatroom:" + roomId + ":messages:page:0";
+        List<ChatResponseDto> cached = redisTemplate.opsForList().range(redisKey, 0, -1);
+        if (cached != null && !cached.isEmpty()) {
+            return new PageImpl<>(cached, pageable, cached.size());
+        }
 
-        Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom,pageable);
+        Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom, pageable);
+        List<ChatResponseDto> result = chatMessagePage.map(ChatResponseDto::new).toList();
 
-        return chatMessagePage.map(ChatResponseDto::new);
+        redisTemplate.opsForList().rightPushAll(redisKey, result.toArray());
+        redisTemplate.expire(redisKey, Duration.ofSeconds(60));
 
-
+        return new PageImpl<>(result, pageable, result.size());
     }
+
 
 
 }

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -24,6 +24,7 @@ import com.example.backend.domain.user.service.UserService;
 import com.example.backend.global.utils.dto.ApiResponse;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -188,6 +189,8 @@ public class ChatMessageService {
         if (cached != null && !cached.isEmpty()) {
             return new PageImpl<>(cached, pageable, cached.size());
         }
+
+        // 실제 메시지가 없다는 표시를 Redis에 남김 → 예: "__empty__" 같은 마커
 
         // 🔒 캐시 MISS → 락 거는 메서드 따로 분리
         return getChatMessageWithLock(roomId, pageable);

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -155,19 +155,6 @@ public class ChatMessageService {
         return chatMessageRepository.save(chatMessage);
     }
 
-//    public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable){
-//        User user = userService.findById(tokenService.getIdFromToken());
-//        ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
-//
-//        //참여중인 채팅방 아니면 메시지 조회 못함
-//        if(chatUserRepository.findByUserAndChatRoom(user,chatRoom).isEmpty()){
-//            throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
-//        }
-//        Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom,pageable);
-//
-//        return chatMessagePage.map(ChatResponseDto::new);
-//    }
-
     @RedisCacheLock(key = "'chatroom:' + #roomId + ':messages:page:0'")
     public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable) {
         User user = userService.findById(tokenService.getIdFromToken());

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
@@ -42,6 +43,9 @@ public class ChatMessageService {
     private final ChatRoomService chatRoomService;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final TokenService tokenService;
+
+
+    private final RedisTemplate redisTemplate;
 
     // for 알림
     private final ApplicationEventPublisher eventPublisher;
@@ -143,7 +147,7 @@ public class ChatMessageService {
         return chatMessageRepository.save(chatMessage);
     }
 
-    public Page<ChatMessage> getChatMessage(Long roomId, Pageable pageable){
+    public Page<ChatResponseDto> getChatMessage(Long roomId, Pageable pageable){
         User user = userService.findById(tokenService.getIdFromToken());
         ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
 
@@ -151,8 +155,15 @@ public class ChatMessageService {
         if(chatUserRepository.findByUserAndChatRoom(user,chatRoom).isEmpty()){
             throw new BusinessLogicException(ExceptionCode.NOT_ENTER_CHAT_ROOM);
         };
+        List<ChatResponseDto> cached = redisTemplate.opsForList().range(key, 0, -1);
+        if (cached != null && !cached.isEmpty()) return cached; // 캐시 HIT
 
-        return chatMessageRepository.findByChatRoom(chatRoom,pageable);
+
+        Page<ChatMessage> chatMessagePage = chatMessageRepository.findByChatRoom(chatRoom,pageable);
+
+        return chatMessagePage.map(ChatResponseDto::new);
+
+
     }
 
 

--- a/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/chatMessage/service/ChatMessageService.java
@@ -185,12 +185,10 @@ public class ChatMessageService {
 
         List<ChatResponseDto> cached = chatMessageRedisService.getCachedMessages(roomId, pageable.getPageNumber());
 
-        // 🔁 캐시 HIT → 락 안 거치고 바로 반환
-        if (cached != null && !cached.isEmpty()) {
+        // ✅ null만 MISS → empty 포함해서 HIT
+        if (cached != null) {
             return new PageImpl<>(cached, pageable, cached.size());
         }
-
-        // 실제 메시지가 없다는 표시를 Redis에 남김 → 예: "__empty__" 같은 마커
 
         // 🔒 캐시 MISS → 락 거는 메서드 따로 분리
         return getChatMessageWithLock(roomId, pageable);

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
@@ -38,7 +38,11 @@ public class ChatMessageRedisService {
 
 
     public void cacheMessages(Long roomId, List<ChatResponseDto> messages, Duration ttl, int page) {
+        String key = getMessageCacheKey(roomId, page);
+        chatMessageRedisTemplate.delete(key);
         if (messages == null || messages.isEmpty()) {
+            chatMessageRedisTemplate.opsForList().rightPush(key, "__empty__");
+            chatMessageRedisTemplate.expire(key, ttl);
             log.warn("📭 캐시 저장 시 빈 메시지 리스트 - 저장 생략 (roomId: {}, page: {})", roomId, page);
             return;
         }

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
@@ -2,9 +2,12 @@ package com.example.backend.domain.chat.redis;
 
 import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,36 +16,50 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ChatMessageRedisService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+
+    private final RedisTemplate<String, Object> chatMessageRedisTemplate;
     private final RedissonClient redissonClient;
 
     @Getter
     @Value("${redis-custom.chat-message-TTL}")
-    public int messageTTL=1000;
+    public int messageTTL;
 
 
-    public String getMessageCacheKey(Long roomId) {
-        return "chatroom:" + roomId + ":messages:page:0";
-    }
 
-    public List<ChatResponseDto> getCachedMessages(Long roomId) {
-        String key = getMessageCacheKey(roomId);
-        List<Object> cached = redisTemplate.opsForList().range(key, 0, -1);
+    public List<ChatResponseDto> getCachedMessages(Long roomId, int page) {
+        String key = getMessageCacheKey(roomId, page);
+        List<Object> cached = chatMessageRedisTemplate.opsForList().range(key, 0, -1);
         if (cached == null || cached.isEmpty()) return null;
         return cached.stream().map(obj -> (ChatResponseDto) obj).toList();
     }
 
-    public void cacheMessages(Long roomId, List<ChatResponseDto> messages, Duration ttl) {
-        String key = getMessageCacheKey(roomId);
-        redisTemplate.delete(key); // 기존 제거
-        redisTemplate.opsForList().rightPushAll(key, messages.toArray());
-        redisTemplate.expire(key, ttl);
+
+    public void cacheMessages(Long roomId, List<ChatResponseDto> messages, Duration ttl, int page) {
+        if (messages == null || messages.isEmpty()) {
+            log.warn("📭 캐시 저장 시 빈 메시지 리스트 - 저장 생략 (roomId: {}, page: {})", roomId, page);
+            return;
+        }
+
+        String key = getMessageCacheKey(roomId, page);
+
+        // 기존 데이터 제거 후 새로 삽입
+        chatMessageRedisTemplate.delete(key);
+        chatMessageRedisTemplate.opsForList().rightPushAll(key, new ArrayList<>(messages));
+        chatMessageRedisTemplate.expire(key, ttl);
     }
+
+
 
     public RLock getMessageLock(Long roomId) {
         return redissonClient.getLock("lock:chatroom:" + roomId + ":page:0");
     }
+
+    public String getMessageCacheKey(Long roomId, int page) {
+        return "chatroom:" + roomId + ":messages:page:" + page;
+    }
+
 
 }

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
@@ -4,6 +4,7 @@ import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +33,19 @@ public class ChatMessageRedisService {
     public List<ChatResponseDto> getCachedMessages(Long roomId, int page) {
         String key = getMessageCacheKey(roomId, page);
         List<Object> cached = chatMessageRedisTemplate.opsForList().range(key, 0, -1);
+
         if (cached == null || cached.isEmpty()) return null;
-        return cached.stream().map(obj -> (ChatResponseDto) obj).toList();
+
+        // ❗ "__empty__" 마커 확인 (직렬화 방식에 따라 문자열 비교 주의)
+        if (cached.size() == 1 && cached.get(0) instanceof String str && "__empty__".equals(str)) {
+            return Collections.emptyList();
+        }
+
+        // ✅ 안전하게 캐스팅
+        return cached.stream()
+                .filter(ChatResponseDto.class::isInstance)
+                .map(ChatResponseDto.class::cast)
+                .toList();
     }
 
 
@@ -47,7 +59,6 @@ public class ChatMessageRedisService {
             return;
         }
 
-        String key = getMessageCacheKey(roomId, page);
 
         // 기존 데이터 제거 후 새로 삽입
         chatMessageRedisTemplate.delete(key);

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
@@ -20,10 +20,10 @@ public class ChatMessageRedisService {
 
     @Getter
     @Value("${redis-custom.chat-message-TTL}")
-    public int messageTTL;
+    public int messageTTL=1000;
 
 
-    private String getMessageCacheKey(Long roomId) {
+    public String getMessageCacheKey(Long roomId) {
         return "chatroom:" + roomId + ":messages:page:0";
     }
 
@@ -43,10 +43,6 @@ public class ChatMessageRedisService {
 
     public RLock getMessageLock(Long roomId) {
         return redissonClient.getLock("lock:chatroom:" + roomId + ":page:0");
-    }
-
-    public String getChatMessageCacheKey(Long roomId) {
-        return "chatroom:" + roomId + ":messages:page:0";
     }
 
 }

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
@@ -1,0 +1,41 @@
+package com.example.backend.domain.chat.redis;
+
+import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageRedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedissonClient redissonClient;
+
+
+    private String getMessageCacheKey(Long roomId) {
+        return "chatroom:" + roomId + ":messages:page:0";
+    }
+
+    public List<ChatResponseDto> getCachedMessages(Long roomId) {
+        String key = getMessageCacheKey(roomId);
+        List<Object> cached = redisTemplate.opsForList().range(key, 0, -1);
+        if (cached == null || cached.isEmpty()) return null;
+        return cached.stream().map(obj -> (ChatResponseDto) obj).toList();
+    }
+
+    public void cacheMessages(Long roomId, List<ChatResponseDto> messages, Duration ttl) {
+        String key = getMessageCacheKey(roomId);
+        redisTemplate.delete(key); // 기존 제거
+        redisTemplate.opsForList().rightPushAll(key, messages.toArray());
+        redisTemplate.expire(key, ttl);
+    }
+
+    public RLock getMessageLock(Long roomId) {
+        return redissonClient.getLock("lock:chatroom:" + roomId + ":page:0");
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/ChatMessageRedisService.java
@@ -3,9 +3,11 @@ package com.example.backend.domain.chat.redis;
 import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
 import java.time.Duration;
 import java.util.List;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +17,10 @@ public class ChatMessageRedisService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final RedissonClient redissonClient;
+
+    @Getter
+    @Value("${redis-custom.chat-message-TTL}")
+    public int messageTTL;
 
 
     private String getMessageCacheKey(Long roomId) {
@@ -38,4 +44,9 @@ public class ChatMessageRedisService {
     public RLock getMessageLock(Long roomId) {
         return redissonClient.getLock("lock:chatroom:" + roomId + ":page:0");
     }
+
+    public String getChatMessageCacheKey(Long roomId) {
+        return "chatroom:" + roomId + ":messages:page:0";
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/RedisCacheLock.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/RedisCacheLock.java
@@ -1,0 +1,16 @@
+// src/main/java/com/example/backend/global/lock/RedisCacheLock.java
+
+package com.example.backend.domain.chat.redis;
+
+import java.lang.annotation.*;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RedisCacheLock {
+    String key(); // SpEL 표현식으로 락 키 지정
+    long waitTime() default 1; // 락 대기 시간 (초)
+    long leaseTime() default 5; // 락 유지 시간 (초)
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/RedisLockAspect.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/RedisLockAspect.java
@@ -25,7 +25,6 @@ import org.springframework.util.StopWatch;
 public class RedisLockAspect {
 
     private final RedissonClient redissonClient;
-    private final RedisTemplate<String, Object> redisTemplate;
 
     @Around("@annotation(redisCacheLock)")
     public Object around(ProceedingJoinPoint joinPoint, RedisCacheLock redisCacheLock) throws Throwable {
@@ -35,16 +34,15 @@ public class RedisLockAspect {
         boolean locked = false;
         StopWatch sw = new StopWatch();
         sw.start();
-
+        //true -> 락 획득 성공
+        locked = lock.tryLock(redisCacheLock.waitTime(), redisCacheLock.leaseTime(), TimeUnit.SECONDS);
         try {
-            locked = lock.tryLock(redisCacheLock.waitTime(), redisCacheLock.leaseTime(), TimeUnit.SECONDS);
-
             if (!locked) {
                 // 락 못 잡았으면 Redis 재확인 or fallback 처리는 서비스단에서
                 throw new IllegalStateException("Redis Lock 획득 실패");
             }
 
-            return joinPoint.proceed(); // 핵심 로직 실행
+            return joinPoint.proceed(); // 핵심 로직 실행 -> getChatMessage())실행하는거임
 
         } finally {
             if (locked && lock.isHeldByCurrentThread()) {

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/RedisLockAspect.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/RedisLockAspect.java
@@ -1,0 +1,71 @@
+package com.example.backend.domain.chat.redis;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisLockAspect {
+
+    private final RedissonClient redissonClient;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Around("@annotation(redisCacheLock)")
+    public Object around(ProceedingJoinPoint joinPoint, RedisCacheLock redisCacheLock) throws Throwable {
+        String lockKey = resolveKey(joinPoint, redisCacheLock.key());
+        RLock lock = redissonClient.getLock("lock:" + lockKey);
+
+        boolean locked = false;
+        StopWatch sw = new StopWatch();
+        sw.start();
+
+        try {
+            locked = lock.tryLock(redisCacheLock.waitTime(), redisCacheLock.leaseTime(), TimeUnit.SECONDS);
+
+            if (!locked) {
+                // 락 못 잡았으면 Redis 재확인 or fallback 처리는 서비스단에서
+                throw new IllegalStateException("Redis Lock 획득 실패");
+            }
+
+            return joinPoint.proceed(); // 핵심 로직 실행
+
+        } finally {
+            if (locked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+            sw.stop();
+            log.info("🔒 락 실행 시간: {}ms (Key: {})", sw.getTotalTimeMillis(), lockKey);
+        }
+    }
+
+    private String resolveKey(ProceedingJoinPoint joinPoint, String keyExpr) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        EvaluationContext context = new StandardEvaluationContext();
+        Object[] args = joinPoint.getArgs();
+        String[] paramNames = new DefaultParameterNameDiscoverer().getParameterNames(method);
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
+        }
+
+        return new SpelExpressionParser().parseExpression(keyExpr).getValue(context, String.class);
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/RedisLockAspect.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/RedisLockAspect.java
@@ -1,5 +1,8 @@
 package com.example.backend.domain.chat.redis;
 
+import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
+import com.example.backend.global.exception.BusinessLogicException;
+import com.example.backend.global.exception.ExceptionCode;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +13,8 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.expression.EvaluationContext;
@@ -26,33 +31,80 @@ public class RedisLockAspect {
 
     private final RedissonClient redissonClient;
 
+    @Autowired
+    private RedisTemplate<String, ChatResponseDto> chatMessageRedisTemplate;
+
+    @Value("${redis-custom.lock-retry}")
+    private int lockRetry;
+
+
+    @Value("${redis-custom.delay-Millis}")
+    private int delayMillis;
+
+    /**
+     * Redis 분산 락 처리 AOP
+     */
     @Around("@annotation(redisCacheLock)")
     public Object around(ProceedingJoinPoint joinPoint, RedisCacheLock redisCacheLock) throws Throwable {
         String lockKey = resolveKey(joinPoint, redisCacheLock.key());
         RLock lock = redissonClient.getLock("lock:" + lockKey);
-
         boolean locked = false;
+
         StopWatch sw = new StopWatch();
         sw.start();
-        //true -> 락 획득 성공
-        locked = lock.tryLock(redisCacheLock.waitTime(), redisCacheLock.leaseTime(), TimeUnit.SECONDS);
+
         try {
+            locked = lock.tryLock(
+                    redisCacheLock.waitTime(),
+                    redisCacheLock.leaseTime(),
+                    TimeUnit.SECONDS
+            );
+
             if (!locked) {
-                // 락 못 잡았으면 Redis 재확인 or fallback 처리는 서비스단에서
-                throw new IllegalStateException("Redis Lock 획득 실패");
+                log.warn("🔒 Redis 락 획득 실패 - 캐시 재시도 진입 (Key: {})", lockKey);
+                Object retryResult = retryGetFromRedis(lockKey);
+                if (retryResult != null) return retryResult;
+
+                log.warn("🔒 캐시 재시도 실패 - 비즈니스 로직 실행 (Key: {})", lockKey);
+                return joinPoint.proceed();
             }
 
-            return joinPoint.proceed(); // 핵심 로직 실행 -> getChatMessage())실행하는거임
+            // 락 획득 성공 → 비즈니스 로직 실행
+            return joinPoint.proceed();
 
-        } finally {
+        }
+        catch (InterruptedException e) {
+             // 스레드의 인터럽트 상태를 복구
+            Thread.currentThread().interrupt();
+            throw new BusinessLogicException(ExceptionCode.REDIS_LOCK_INTERRUPTED);
+        }finally {
             if (locked && lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
             sw.stop();
-            log.info("🔒 락 실행 시간: {}ms (Key: {})", sw.getTotalTimeMillis(), lockKey);
+            log.info("🔓 Redis 락 종료 (Key: {}, 실행 시간: {}ms)", lockKey, sw.getTotalTimeMillis());
         }
     }
 
+    /**
+     * 캐시 키 재조회 로직 - 락 실패 시 일정 시간 대기하며 재시도
+     */
+    private Object retryGetFromRedis(String redisKey) throws InterruptedException {
+        for (int i = 0; i < lockRetry; i++) {
+            Object cached = chatMessageRedisTemplate.opsForValue().get(redisKey);
+            if (cached != null) {
+                log.info("📦 [Redis HIT after Lock 실패 - 재시도 {}회] (Key: {})", i + 1, redisKey);
+                return cached;
+            }
+            Thread.sleep(delayMillis);
+        }
+
+        return null;
+    }
+
+    /**
+     * SpEL 표현식을 실제 파라미터로 변환하여 키 생성
+     */
     private String resolveKey(ProceedingJoinPoint joinPoint, String keyExpr) {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
@@ -60,8 +112,11 @@ public class RedisLockAspect {
         EvaluationContext context = new StandardEvaluationContext();
         Object[] args = joinPoint.getArgs();
         String[] paramNames = new DefaultParameterNameDiscoverer().getParameterNames(method);
-        for (int i = 0; i < paramNames.length; i++) {
-            context.setVariable(paramNames[i], args[i]);
+
+        if (paramNames != null) {
+            for (int i = 0; i < paramNames.length; i++) {
+                context.setVariable(paramNames[i], args[i]);
+            }
         }
 
         return new SpelExpressionParser().parseExpression(keyExpr).getValue(context, String.class);

--- a/backend/src/main/java/com/example/backend/domain/chat/redis/RedisLockAspect.java
+++ b/backend/src/main/java/com/example/backend/domain/chat/redis/RedisLockAspect.java
@@ -4,6 +4,7 @@ import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
 import com.example.backend.global.exception.BusinessLogicException;
 import com.example.backend.global.exception.ExceptionCode;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,8 @@ import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -32,7 +35,7 @@ public class RedisLockAspect {
     private final RedissonClient redissonClient;
 
     @Autowired
-    private RedisTemplate<String, ChatResponseDto> chatMessageRedisTemplate;
+    private RedisTemplate<String, Object> chatMessageRedisTemplate;
 
     @Value("${redis-custom.lock-retry}")
     private int lockRetry;
@@ -48,6 +51,7 @@ public class RedisLockAspect {
     public Object around(ProceedingJoinPoint joinPoint, RedisCacheLock redisCacheLock) throws Throwable {
         String lockKey = resolveKey(joinPoint, redisCacheLock.key());
         RLock lock = redissonClient.getLock("lock:" + lockKey);
+
         boolean locked = false;
 
         StopWatch sw = new StopWatch();
@@ -90,17 +94,26 @@ public class RedisLockAspect {
      * 캐시 키 재조회 로직 - 락 실패 시 일정 시간 대기하며 재시도
      */
     private Object retryGetFromRedis(String redisKey) throws InterruptedException {
+        String actualDataKey = redisKey.replaceFirst("^lock:", "");
+
         for (int i = 0; i < lockRetry; i++) {
-            Object cached = chatMessageRedisTemplate.opsForValue().get(redisKey);
-            if (cached != null) {
-                log.info("📦 [Redis HIT after Lock 실패 - 재시도 {}회] (Key: {})", i + 1, redisKey);
-                return cached;
+            List<Object> rawCached = chatMessageRedisTemplate.opsForList().range(actualDataKey, 0, -1);
+            if (rawCached != null && !rawCached.isEmpty()) {
+                List<ChatResponseDto> cached = rawCached.stream()
+                        .map(obj -> (ChatResponseDto) obj)
+                        .toList();
+                int size = cached.size();
+                log.info("📦 [Redis HIT after Lock 실패 - 재시도 {}회] (Key: {})", i + 1, actualDataKey);
+                return new PageImpl<>(cached, PageRequest.of(0, size == 0 ? 1 : size), size);
             }
+
             Thread.sleep(delayMillis);
         }
 
         return null;
     }
+
+
 
     /**
      * SpEL 표현식을 실제 파라미터로 변환하여 키 생성

--- a/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/domain/user/controller/UserController.java
@@ -374,7 +374,7 @@ public class UserController {
     )
     public ResponseEntity<?> getRequestManager(@RequestParam String managementDashboardName
             , @RequestParam(name = "page", defaultValue = "1") int page,
-                                               @RequestParam(name = "size", defaultValue = "10") int size) {
+                                                @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Page<User> approveUserList = userService.getRequestManagerList(managementDashboardName,
                 PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt")));

--- a/backend/src/main/java/com/example/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/example/backend/global/exception/ExceptionCode.java
@@ -32,6 +32,7 @@ public enum ExceptionCode {
     NOT_ENTER_CHAT_ROOM(404,"참여중인 채팅방이 아닙니다."),
     ALREADY_ENTER_CHAT_ROOM(403,"이미 채팅방에 입장했습니다."),
     FILTER_ACCESS_DENIED(403, "접근이 거부되었습니다. 권한이 부족합니다."),
+    REDIS_LOCK_INTERRUPTED(500, "Redisson 락 처리 중 인터럽트 발생"),
 
     //유저 예외 처리
     NOT_INITIAL_MANAGER(403, "해당 기능은 최초 생성 매니저만 사용할 수 있습니다."),

--- a/backend/src/main/java/com/example/backend/global/redis/RedisConfig.java
+++ b/backend/src/main/java/com/example/backend/global/redis/RedisConfig.java
@@ -1,6 +1,9 @@
 package com.example.backend.global.redis;
 
 import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
@@ -73,11 +76,20 @@ public class RedisConfig {
      * ✅ 채팅 메시지 캐시를 저장할 때 타입 안전성 보장
      */
     @Bean
-    public RedisTemplate<String, ChatResponseDto> chatMessageRedisTemplate(RedisConnectionFactory factory) {
-        RedisTemplate<String, ChatResponseDto> template = new RedisTemplate<>();
+    public RedisTemplate<String, Object> chatMessageRedisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // JSON 직렬화
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        template.setValueSerializer(serializer);
+        template.setHashValueSerializer(serializer);
+
+        template.afterPropertiesSet();
         return template;
     }
 

--- a/backend/src/main/java/com/example/backend/global/redis/RedisConfig.java
+++ b/backend/src/main/java/com/example/backend/global/redis/RedisConfig.java
@@ -26,13 +26,12 @@ public class RedisConfig {
     private String redisPassword;
 
 
-
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
         config.setHostName(redisHost);
         config.setPort(redisPort);
-        config.setPassword(redisPassword);  // 비밀번호 설정 추가
+        //config.setPassword(redisPassword);  // 비밀번호 설정 추가
         return new LettuceConnectionFactory(config);
 
     }

--- a/backend/src/main/java/com/example/backend/global/redis/RedisConfig.java
+++ b/backend/src/main/java/com/example/backend/global/redis/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.example.backend.global.redis;
 
+import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -58,6 +59,25 @@ public class RedisConfig {
 
         return template;
     }
+
+    /**
+     * 채팅 메시지 전용 RedisTemplate 설정
+     * - 키: String
+     * - 값: ChatResponseDto
+     *
+     * ✅ GenericJackson2JsonRedisSerializer를 사용하여 객체를 JSON 형태로 직렬화하여 저장
+     * ✅ Redis에서 꺼낼 때도 자동으로 역직렬화됨
+     * ✅ 채팅 메시지 캐시를 저장할 때 타입 안전성 보장
+     */
+    @Bean
+    public RedisTemplate<String, ChatResponseDto> chatMessageRedisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, ChatResponseDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // JSON 직렬화
+        return template;
+    }
+
 
 
 }

--- a/backend/src/main/java/com/example/backend/global/redis/RedisConfig.java
+++ b/backend/src/main/java/com/example/backend/global/redis/RedisConfig.java
@@ -1,6 +1,9 @@
 package com.example.backend.global.redis;
 
 import com.example.backend.domain.chat.chatMessage.dto.response.ChatResponseDto;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -76,6 +79,14 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // JSON 직렬화
         return template;
+    }
+
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + redisHost + ":" + redisPort);
+        return Redisson.create(config);
     }
 
 

--- a/backend/src/main/java/com/example/backend/global/redis/RedisService.java
+++ b/backend/src/main/java/com/example/backend/global/redis/RedisService.java
@@ -20,8 +20,6 @@ public class RedisService {
         redisTemplate.opsForValue().set(key, value);
     }
 
-
-
     // 저장 + 만료 시간 설정
     public void saveData(String key, String value, Duration timeout) {
         redisTemplate.opsForValue().set(key, value, timeout);

--- a/backend/src/main/java/com/example/backend/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/backend/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -164,6 +164,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 
     public String getAccessToken(HttpServletRequest request){
+        //헤더에 있는지 확인
+        String authorization = request.getHeader("Authorization");
+        if(StringUtils.hasText(authorization) && authorization.startsWith("Bearer ")){
+            return authorization.substring(7);
+        }
 
         //쿠키에 있는지 확인
         Cookie[] cookies = request.getCookies();

--- a/backend/src/main/java/com/example/backend/global/security/jwt/service/TokenService.java
+++ b/backend/src/main/java/com/example/backend/global/security/jwt/service/TokenService.java
@@ -17,6 +17,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +32,12 @@ public class TokenService {
 
 
     public String getTokenFromRequest() {
+
+        //헤더에 있는지 확인
+        String authorization = httpServletRequest.getHeader("Authorization");
+        if(StringUtils.hasText(authorization) && authorization.startsWith("Bearer ")){
+            return authorization.substring(7);
+        }
 
         //쿠키에 있는지 확인
         Cookie[] cookies = httpServletRequest.getCookies();
@@ -116,6 +123,9 @@ public class TokenService {
 
         httpServletResponse.addCookie(accessTokenCookie);
         httpServletResponse.addCookie(refreshTokenCookie);
+
+        //k6 테스트용
+        httpServletResponse.setHeader("Authorization", "Bearer " + accessToken);
     }
 
     public void generateAccessToken(String name, String value) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -48,6 +48,7 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
+    org.redisson: DEBUG
 custom:
   dev:
     cookieDomain: localhost

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -48,7 +48,6 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
-    org.redisson: DEBUG
 custom:
   dev:
     cookieDomain: localhost


### PR DESCRIPTION
## 📒 개요

메시지 조회 시 **Redis 캐시 적용 및 Redisson 기반 분산 락 도입**  
캐시 미스 시 동시성 문제 방지를 위한 락 처리 및 더블체크(Double-Check) 로직 적용

---

## 📍 Issue 번호

#519 



## 🛠️ 작업사항

- `@RedisCacheLock` 커스텀 어노테이션 도입  
  - SpEL 기반 키 구성  
  - `waitTime`, `leaseTime`, `TimeUnit` 설정 가능

- `RedisLockAspect` AOP 구현  
  - Redisson을 활용한 분산 락 처리  
  - 락 획득 실패 시 재시도 로직 적용 (Double-Check)

- `ChatMessageRedisService` 수정  
  - 빈 리스트일 경우 `"__empty__"` 마커 캐싱
  - 캐시 마커 판별 로직으로 빈 리스트 재사용 가능

- `ChatMessageService#getChatMessage()` 변경  
  - 캐시 HIT 시 락 없이 바로 반환  
  - 캐시 MISS 시 분산 락 후 DB 조회 + 캐시 저장

- k6 + Grafana 부하 테스트 적용  
  - 빈 content 응답을 실패로 간주하지 않도록 `check()` 조건 정비  
  - 응답 구조(JSON) 유효성만 검증하도록 수정



## 📸 스크린샷 (선택)
<img width="986" height="635" alt="스크린샷 2025-08-03 오전 12 43 30" src="https://github.com/user-attachments/assets/ba57e4a7-ce07-4c5b-888c-b72bc3576b42" />

> 📈 성능 테스트 결과 예시:
>
> - ✅ 캐시 적용 후 평균 응답 시간 감소
> - ✅ 동시성 요청 처리 중 정합성 문제 없음
> - ✅ 실패율 안정적으로 0% 유지



## ✅ 기타 참고사항
- 빈 리스트도 캐시하여 동일 요청 반복 시 낭비 방지
- 분산 락은 캐시 미스 상황에서만 동작하며 Double-Check 구조로 불필요한 락 방지
